### PR TITLE
🐛fixed vpc deletion failure

### DIFF
--- a/pkg/cloud/services/securitygroup/securitygroups.go
+++ b/pkg/cloud/services/securitygroup/securitygroups.go
@@ -163,13 +163,14 @@ func (s *Service) ReconcileSecurityGroups() error {
 func (s *Service) DeleteSecurityGroups() error {
 	conditions.MarkFalse(s.scope.InfraCluster(), infrav1.ClusterSecurityGroupsReadyCondition, clusterv1.DeletingReason, clusterv1.ConditionSeverityInfo, "")
 
-	if s.scope.VPC().ID == "" {
-		conditions.MarkFalse(s.scope.InfraCluster(), infrav1.ClusterSecurityGroupsReadyCondition, clusterv1.DeletedReason, clusterv1.ConditionSeverityInfo, "")
-		return nil
-	}
-
 	if err := s.scope.PatchObject(); err != nil {
 		return err
+	}
+
+	if s.scope.VPC().ID == "" {
+		s.scope.V(2).Info("Skipping security group deletion, vpc-id is nil", "vpc-id", s.scope.VPC().ID)
+		conditions.MarkFalse(s.scope.InfraCluster(), infrav1.ClusterSecurityGroupsReadyCondition, clusterv1.DeletedReason, clusterv1.ConditionSeverityInfo, "")
+		return nil
 	}
 
 	for _, sg := range s.scope.SecurityGroups() {

--- a/pkg/cloud/services/securitygroup/securitygroups.go
+++ b/pkg/cloud/services/securitygroup/securitygroups.go
@@ -194,6 +194,11 @@ func (s *Service) DeleteSecurityGroups() error {
 		}
 	}
 
+	if s.scope.VPC().ID == "" {
+		s.scope.V(0).Info("skipping cluster owned security group delete, vpc id nil", "vpc-id", s.scope.VPC().ID)
+		return nil
+	}
+
 	clusterGroups, err := s.describeClusterOwnedSecurityGroups()
 	if err != nil {
 		return err

--- a/pkg/cloud/services/securitygroup/securitygroups.go
+++ b/pkg/cloud/services/securitygroup/securitygroups.go
@@ -162,15 +162,14 @@ func (s *Service) ReconcileSecurityGroups() error {
 
 func (s *Service) DeleteSecurityGroups() error {
 	conditions.MarkFalse(s.scope.InfraCluster(), infrav1.ClusterSecurityGroupsReadyCondition, clusterv1.DeletingReason, clusterv1.ConditionSeverityInfo, "")
-
-	if err := s.scope.PatchObject(); err != nil {
-		return err
-	}
-
 	if s.scope.VPC().ID == "" {
 		s.scope.V(2).Info("Skipping security group deletion, vpc-id is nil", "vpc-id", s.scope.VPC().ID)
 		conditions.MarkFalse(s.scope.InfraCluster(), infrav1.ClusterSecurityGroupsReadyCondition, clusterv1.DeletedReason, clusterv1.ConditionSeverityInfo, "")
 		return nil
+	}
+
+	if err := s.scope.PatchObject(); err != nil {
+		return err
 	}
 
 	for _, sg := range s.scope.SecurityGroups() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes cluster deletion failure. 
If a cluster is created when with VPC quota limit is exhausted vpc id is not provided, when try to delete the cluster, it gets stuck at delete security groups because there is no VPC-ID.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2227

