### PR TITLE
BET-5064: EKS : Observed error "disabling EKS encryption is not allowed after it has been enabled" after enabling secrets encryption

### DIFF
--- a/controlplane/eks/api/v1alpha4/awsmanagedcontrolplane_webhook.go
+++ b/controlplane/eks/api/v1alpha4/awsmanagedcontrolplane_webhook.go
@@ -139,7 +139,11 @@ func (r *AWSManagedControlPlane) ValidateUpdate(old runtime.Object) error {
 	}
 
 	// If encryptionConfig is already set, do not allow change in provider
-	if r.Spec.EncryptionConfig != nil && oldAWSManagedControlplane.Spec.EncryptionConfig != nil && *r.Spec.EncryptionConfig.Provider != *oldAWSManagedControlplane.Spec.EncryptionConfig.Provider {
+	if r.Spec.EncryptionConfig != nil &&
+		r.Spec.EncryptionConfig.Provider != nil &&
+		oldAWSManagedControlplane.Spec.EncryptionConfig != nil &&
+		oldAWSManagedControlplane.Spec.EncryptionConfig.Provider != nil &&
+		*r.Spec.EncryptionConfig.Provider != *oldAWSManagedControlplane.Spec.EncryptionConfig.Provider {
 		allErrs = append(allErrs,
 			field.Invalid(field.NewPath("spec", "encryptionConfig", "provider"), r.Spec.EncryptionConfig.Provider, "changing EKS encryption is not allowed after it has been enabled"),
 		)

--- a/pkg/cloud/services/eks/cluster.go
+++ b/pkg/cloud/services/eks/cluster.go
@@ -690,12 +690,19 @@ func compareEncryptionConfig(updatedEncryptionConfig, existingEncryptionConfig [
 		return false
 	}
 	for index, encryptionConfig := range updatedEncryptionConfig {
-		if encryptionConfig.Provider != existingEncryptionConfig[index].Provider {
+		if getKeyArn(encryptionConfig) != getKeyArn(existingEncryptionConfig[index]) {
 			return false
 		}
-		if cmp.Equals(encryptionConfig.Resources, existingEncryptionConfig[index].Resources) {
+		if !cmp.Equals(encryptionConfig.Resources, existingEncryptionConfig[index].Resources) {
 			return false
 		}
 	}
 	return true
+}
+
+func getKeyArn(encryptionConfig *eks.EncryptionConfig) string {
+	if encryptionConfig.Provider != nil {
+		return aws.StringValue(encryptionConfig.Provider.KeyArn)
+	}
+	return ""
 }

--- a/pkg/cloud/services/eks/cluster_test.go
+++ b/pkg/cloud/services/eks/cluster_test.go
@@ -443,11 +443,24 @@ func TestReconcileEKSEncryptionConfig(t *testing.T) {
 		expectError         bool
 	}{
 		{
-			name:                "no upgrade necessary",
+			name:                "no upgrade necessary - encryption disabled",
 			oldEncryptionConfig: &ekscontrolplanev1.EncryptionConfig{},
 			newEncryptionConfig: &ekscontrolplanev1.EncryptionConfig{},
 			expect:              func(m *mock_eksiface.MockEKSAPIMockRecorder) {},
 			expectError:         false,
+		},
+		{
+			name: "no upgrade necessary - encryption config unchanged",
+			oldEncryptionConfig: &ekscontrolplanev1.EncryptionConfig{
+				Provider:  pointer.String("provider"),
+				Resources: []*string{pointer.String("foo"), pointer.String("bar")},
+			},
+			newEncryptionConfig: &ekscontrolplanev1.EncryptionConfig{
+				Provider:  pointer.String("provider"),
+				Resources: []*string{pointer.String("foo"), pointer.String("bar")},
+			},
+			expect:      func(m *mock_eksiface.MockEKSAPIMockRecorder) {},
+			expectError: false,
 		},
 		{
 			name:                "needs upgrade",

--- a/pkg/internal/cmp/slice.go
+++ b/pkg/internal/cmp/slice.go
@@ -42,7 +42,7 @@ func Equals(slice1, slice2 []*string) bool {
 
 	if len(slice1) == len(slice2) {
 		for i, v := range slice1 {
-			if pointer.StringEqual(v, slice2[i]) {
+			if !pointer.StringEqual(v, slice2[i]) {
 				return false
 			}
 		}

--- a/pkg/internal/cmp/slice_test.go
+++ b/pkg/internal/cmp/slice_test.go
@@ -30,9 +30,9 @@ func TestCompareSlices(t *testing.T) {
 	slice2 := []*string{pointer.String("bar"), pointer.String("foo")}
 
 	expected := Equals(slice1, slice2)
-	g.Expect(expected, true)
+	g.Expect(expected).To(BeTrue())
 
 	slice2 = append(slice2, pointer.String("test"))
 	expected = Equals(slice1, slice2)
-	g.Expect(expected, false)
+	g.Expect(expected).To(BeFalse())
 }


### PR DESCRIPTION
## **State**
### READY

## **What is the purpose of the pull request**
EKS : Observed error "disabling EKS encryption is not allowed after it has been enabled" after enabling secrets encryption

## **Implementation**
Changed logic to process encryption configuration.



## **Brief change log**
(for example:)

## **Committer checklist**
Verified on:

- [x] EKS