### PR TITLE
BET-5206: AwsCluster stuck at deleting state throwing Error

### DIFF
--- a/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/cluster_api_controller.go
@@ -96,6 +96,7 @@ func (t Template) ControllersPolicy() *infrav1.PolicyDocument {
 				"ec2:DeleteInternetGateway",
 				"ec2:DeleteNatGateway",
 				"ec2:DeleteRouteTable",
+				"ec2:ReplaceRoute",
 				"ec2:DeleteSecurityGroup",
 				"ec2:DeleteSubnet",
 				"ec2:DeleteTags",

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/customsuffix.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/customsuffix.yaml
@@ -149,6 +149,7 @@ Resources:
           - ec2:DeleteInternetGateway
           - ec2:DeleteNatGateway
           - ec2:DeleteRouteTable
+          - ec2:ReplaceRoute
           - ec2:DeleteSecurityGroup
           - ec2:DeleteSubnet
           - ec2:DeleteTags

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/default.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/default.yaml
@@ -149,6 +149,7 @@ Resources:
           - ec2:DeleteInternetGateway
           - ec2:DeleteNatGateway
           - ec2:DeleteRouteTable
+          - ec2:ReplaceRoute
           - ec2:DeleteSecurityGroup
           - ec2:DeleteSubnet
           - ec2:DeleteTags

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_all_secret_backends.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_all_secret_backends.yaml
@@ -147,6 +147,7 @@ Resources:
           - ec2:CreateNatGateway
           - ec2:CreateRoute
           - ec2:CreateRouteTable
+          - ec2:ReplaceRoute
           - ec2:CreateSecurityGroup
           - ec2:CreateSubnet
           - ec2:CreateTags

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_bootstrap_user.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_bootstrap_user.yaml
@@ -154,6 +154,7 @@ Resources:
           - ec2:DeleteInternetGateway
           - ec2:DeleteNatGateway
           - ec2:DeleteRouteTable
+          - ec2:ReplaceRoute
           - ec2:DeleteSecurityGroup
           - ec2:DeleteSubnet
           - ec2:DeleteTags

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_custom_bootstrap_user.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_custom_bootstrap_user.yaml
@@ -146,6 +146,7 @@ Resources:
           - ec2:CreateNatGateway
           - ec2:CreateRoute
           - ec2:CreateRouteTable
+          - ec2:ReplaceRoute
           - ec2:CreateSecurityGroup
           - ec2:CreateSubnet
           - ec2:CreateTags

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_different_instance_profiles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_different_instance_profiles.yaml
@@ -141,6 +141,7 @@ Resources:
           - ec2:CreateNatGateway
           - ec2:CreateRoute
           - ec2:CreateRouteTable
+          - ec2:ReplaceRoute
           - ec2:CreateSecurityGroup
           - ec2:CreateSubnet
           - ec2:CreateTags

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_default_roles.yaml
@@ -141,6 +141,7 @@ Resources:
           - ec2:CreateNatGateway
           - ec2:CreateRoute
           - ec2:CreateRouteTable
+          - ec2:ReplaceRoute
           - ec2:CreateSecurityGroup
           - ec2:CreateSubnet
           - ec2:CreateTags

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_disable.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_disable.yaml
@@ -141,6 +141,7 @@ Resources:
           - ec2:CreateNatGateway
           - ec2:CreateRoute
           - ec2:CreateRouteTable
+          - ec2:ReplaceRoute
           - ec2:CreateSecurityGroup
           - ec2:CreateSubnet
           - ec2:CreateTags

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_kms_prefix.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_eks_kms_prefix.yaml
@@ -141,6 +141,7 @@ Resources:
           - ec2:CreateNatGateway
           - ec2:CreateRoute
           - ec2:CreateRouteTable
+          - ec2:ReplaceRoute
           - ec2:CreateSecurityGroup
           - ec2:CreateSubnet
           - ec2:CreateTags

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_extra_statements.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_extra_statements.yaml
@@ -146,6 +146,7 @@ Resources:
           - ec2:CreateNatGateway
           - ec2:CreateRoute
           - ec2:CreateRouteTable
+          - ec2:ReplaceRoute
           - ec2:CreateSecurityGroup
           - ec2:CreateSubnet
           - ec2:CreateTags

--- a/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_ssm_secret_backend.yaml
+++ b/cmd/clusterawsadm/cloudformation/bootstrap/fixtures/with_ssm_secret_backend.yaml
@@ -141,6 +141,7 @@ Resources:
           - ec2:CreateNatGateway
           - ec2:CreateRoute
           - ec2:CreateRouteTable
+          - ec2:ReplaceRoute
           - ec2:CreateSecurityGroup
           - ec2:CreateSubnet
           - ec2:CreateTags


### PR DESCRIPTION
AwsCluster stuck at deleting state throwing Error due to missing permission in Controller Policy.

its required for https://github.com/spectrocloud/cluster-api-provider-aws/blob/671166141dbfb2fa7ec30f5dd7625f12ed7b6ba8/pkg/cloud/services/network/routetables.go#L88






Changes are already merged into upstream https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3492