### PR TITLE
BET-6063: deletion fails for aws cluster with vpc limit exceeded

### DIFF
--- a/pkg/cloud/awserrors/errors.go
+++ b/pkg/cloud/awserrors/errors.go
@@ -50,6 +50,7 @@ const (
 	SubnetNotFound                          = "InvalidSubnetID.NotFound"
 	UnrecognizedClientException             = "UnrecognizedClientException"
 	VPCNotFound                             = "InvalidVpcID.NotFound"
+	VPCMissingParameter                     = "MissingParameter"
 	ErrCodeRepositoryAlreadyExistsException = "RepositoryAlreadyExistsException"
 )
 

--- a/pkg/cloud/services/network/vpc.go
+++ b/pkg/cloud/services/network/vpc.go
@@ -217,6 +217,13 @@ func (s *Service) deleteVPC() error {
 			s.scope.V(4).Info("Skipping VPC deletion, VPC not found")
 			return nil
 		}
+
+		// Ignore if VPC ID is not present,
+		if code, ok := awserrors.Code(err); ok && code == awserrors.VPCMissingParameter {
+			s.scope.V(4).Info("Skipping VPC deletion, VPC ID not present")
+			return nil
+		}
+
 		record.Warnf(s.scope.InfraCluster(), "FailedDeleteVPC", "Failed to delete managed VPC %q: %v", vpc.ID, err)
 		return errors.Wrapf(err, "failed to delete vpc %q", vpc.ID)
 	}


### PR DESCRIPTION
## **State**
### READY

## **What is the purpose of the pull request**
deletion fails for aws cluster with vpc limit exceeded

## **Implementation**
Issue: In case cluster creation didn't go through due to the VPC limit being exceeded, the VPC ID will be nil and during deletion of the such cluster, the AWS client will give the error.

```
│ E0907 09:53:16.390472       1 network.go:89] controller/awscluster "msg"="non-fatal: VPC ID is missing, " "error"=null "cluster"="am-cluster-123-4" "name"="am-cluster-123-4" "namespace"="am-cluster-123-4" "reco │
│ nciler group"="infrastructure.cluster.x-k8s.io" "reconciler 
```

Fix: Check the error code during VPC deletion and skip it if the error code is "MissingParameter"



## **Brief change log**
(for example:)

## **Committer checklist**
Verified on:

- [x] AWS