### PR TITLE
PCP-1561: OIDC identity providers created by Spectrocloud are not getting cleaned up after cluster deprovisioning.

### DIFF
--- a/pkg/cloud/services/eks/config.go
+++ b/pkg/cloud/services/eks/config.go
@@ -161,6 +161,12 @@ func (s *Service) updateCAPIKubeconfigSecret(ctx context.Context, configSecret *
 	}
 
 	userName := s.getKubeConfigUserName(*cluster.Name, false)
+
+	if config.AuthInfos[userName] == nil {
+		config.AuthInfos[userName] = &api.AuthInfo{
+			Token: token,
+		}
+	}
 	config.AuthInfos[userName].Token = token
 
 	out, err := clientcmd.Write(*config)


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
