### PR TITLE
add cert-manager annotation to pod-identity-webhook mutatingwebhookco…

### DIFF
--- a/pkg/cloud/services/iam/podidentitywebhook.go
+++ b/pkg/cloud/services/iam/podidentitywebhook.go
@@ -326,6 +326,20 @@ func reconcileMutatingWebHook(ctx context.Context, ns string, secret *corev1.Sec
 	}
 
 	if check.UID != "" {
+		updateAnnotations := false
+		if len(check.Annotations) == 0 {
+			check.Annotations = map[string]string{
+				certManagerInjectCAAnnotation: fmt.Sprintf("%s/%s", ns, secret.Name),
+			}
+			updateAnnotations = true
+		} else if check.Annotations[certManagerInjectCAAnnotation] == "" {
+			check.Annotations[certManagerInjectCAAnnotation] = fmt.Sprintf("%s/%s", ns, secret.Name)
+			updateAnnotations = true
+		}
+
+		if updateAnnotations {
+			return remoteClient.Update(ctx, check)
+		}
 		return nil
 	}
 

--- a/pkg/cloud/services/iam/podidentitywebhook.go
+++ b/pkg/cloud/services/iam/podidentitywebhook.go
@@ -3,6 +3,7 @@ package iam
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	v14 "k8s.io/api/admissionregistration/v1"
 	v13 "k8s.io/api/apps/v1"
@@ -17,6 +18,8 @@ import (
 )
 
 const (
+	certManagerInjectCAAnnotation = "cert-manager.io/inject-ca-from"
+
 	podIdentityWebhookName  = "pod-identity-webhook"
 	podIdentityWebhookImage = "amazon/amazon-eks-pod-identity-webhook:v0.5.2"
 
@@ -332,6 +335,9 @@ func reconcileMutatingWebHook(ctx context.Context, ns string, secret *corev1.Sec
 	}
 
 	mwhMeta := objectMeta(podIdentityWebhookName, ns)
+	mwhMeta.Annotations = map[string]string{
+		certManagerInjectCAAnnotation: fmt.Sprintf("%s/%s", ns, secret.Name),
+	}
 	fail := v14.Ignore
 	none := v14.SideEffectClassNone
 	mutate := "/mutate"


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
<!-- Enter a description of the change and why this change is needed -->
We need this PR so that when certs are changed cert-manager knows to update the ca information stored for pod-identity-webhook MutatingWebhookConfiguration.  This is done by ensuring the correct cert-manager annotation is present on the resource so that it can pull updated cert information from the given Secret.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://spectrocloud.atlassian.net/browse/PCP-2363

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
