### PR TITLE
log set of issues when node group in degraded state

### DIFF
--- a/pkg/cloud/services/eks/nodegroup.go
+++ b/pkg/cloud/services/eks/nodegroup.go
@@ -537,7 +537,7 @@ func (s *NodegroupService) reconcileNodegroup() error {
 		return errors.Wrap(err, "failed to set status")
 	}
 
-	if s.scope.ManagedMachinePool.Status.FailureMessage != nil {
+	if s.scope.ManagedMachinePool.Status.FailureReason != nil && s.scope.ManagedMachinePool.Status.FailureMessage != nil {
 		return errors.Errorf("reason: %v message: %s",
 			*s.scope.ManagedMachinePool.Status.FailureReason, *s.scope.ManagedMachinePool.Status.FailureMessage)
 	}

--- a/pkg/cloud/services/eks/nodegroup_test.go
+++ b/pkg/cloud/services/eks/nodegroup_test.go
@@ -1,0 +1,43 @@
+package eks
+
+import (
+	"github.com/aws/aws-sdk-go/service/eks"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/cluster-api-provider-aws/exp/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
+	"testing"
+)
+
+func TestSetStatus(t *testing.T) {
+	g := NewWithT(t)
+	degraded := eks.NodegroupStatusDegraded
+	code := eks.NodegroupIssueCodeAsgInstanceLaunchFailures
+	message := "failed due to vcpu limits"
+	resourceId := "my-worker-nodes"
+
+	s := &NodegroupService{
+		scope: &scope.ManagedMachinePoolScope{
+			ManagedMachinePool: &v1beta1.AWSManagedMachinePool{
+				Status: v1beta1.AWSManagedMachinePoolStatus{
+					Ready: false,
+				},
+			},
+		},
+	}
+
+	issue := &eks.Issue{
+		Code:        &code,
+		Message:     &message,
+		ResourceIds: []*string{&resourceId},
+	}
+	ng := &eks.Nodegroup{
+		Status: &degraded,
+		Health: &eks.NodegroupHealth{
+			Issues: []*eks.Issue{issue},
+		},
+	}
+
+	err := s.setStatus(ng)
+	g.Expect(err).ToNot(BeNil())
+	g.Expect(err.Error()).To(ContainSubstring(issue.GoString()))
+}


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
This PR adds a more verbose error message when node groups for eks clusters are found to be in a degraded state.  
Returns an error containing a set of the issues.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://spectrocloud.atlassian.net/browse/PCP-2384


**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

Screenshot of log showing in Palette UI:
![degradedNodeHealthIssuesLog](https://github.com/spectrocloud/cluster-api-provider-aws/assets/154267435/ceaa647f-a3ef-4308-961b-08f57cc54f82)

