### PR TITLE
PCP-1561: OIDC identity providers created by Spectrocloud are not getting cleaned up after cluster deprovisoning.

### DIFF
--- a/pkg/cloud/services/eks/oidc.go
+++ b/pkg/cloud/services/eks/oidc.go
@@ -52,6 +52,9 @@ func (s *Service) reconcileOIDCProvider(cluster *eks.Cluster) error {
 			return errors.Wrap(err, "failed to create OIDC provider")
 		}
 		s.scope.ControlPlane.Status.OIDCProvider.ARN = oidcProvider
+		anno := s.scope.ControlPlane.GetAnnotations()
+		anno["aws.spectrocloud.com/oidcProviderArn"] = oidcProvider
+		s.scope.ControlPlane.SetAnnotations(anno)
 		if err := s.scope.PatchObject(); err != nil {
 			return errors.Wrap(err, "failed to update control plane with OIDC provider ARN")
 		}
@@ -134,11 +137,18 @@ func (s *Service) reconcileTrustPolicy() error {
 }
 
 func (s *Service) deleteOIDCProvider() error {
-	if !s.scope.ControlPlane.Spec.AssociateOIDCProvider || s.scope.ControlPlane.Status.OIDCProvider.ARN == "" {
+	anno := s.scope.ControlPlane.GetAnnotations()
+	arn := anno["aws.spectrocloud.com/oidcProviderArn"]
+
+	if arn == "" {
+		arn = s.scope.ControlPlane.Status.OIDCProvider.ARN
+	}
+
+	if !s.scope.ControlPlane.Spec.AssociateOIDCProvider || arn == "" {
 		return nil
 	}
 
-	providerARN := s.scope.ControlPlane.Status.OIDCProvider.ARN
+	providerARN := arn
 	if err := s.DeleteOIDCProvider(&providerARN); err != nil {
 		return errors.Wrap(err, "failed to delete OIDC provider")
 	}


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
