### PR TITLE
🐛 iamauth: reconcile mappings as desired state (PCP-2390)

### DIFF
--- a/pkg/cloud/services/iamauth/configmap.go
+++ b/pkg/cloud/services/iamauth/configmap.go
@@ -88,6 +88,44 @@ func (b *configMapBackend) MapUser(mapping ekscontrolplanev1.UserMapping) error 
 	return b.saveAuthConfig(authConfig)
 }
 
+func (b *configMapBackend) MapUsers(mappings []ekscontrolplanev1.UserMapping) error {
+	for _, mapping := range mappings {
+		if errs := mapping.Validate(); errs != nil {
+			return kerrors.NewAggregate(errs)
+		}
+	}
+
+	authConfig, err := b.getAuthConfig()
+	if err != nil {
+		return fmt.Errorf("getting auth config: %w", err)
+	}
+
+	authConfig.UserMappings = []ekscontrolplanev1.UserMapping{}
+
+	authConfig.UserMappings = append(authConfig.UserMappings, mappings...)
+
+	return b.saveAuthConfig(authConfig)
+}
+
+func (b *configMapBackend) MapRoles(mappings []ekscontrolplanev1.RoleMapping) error {
+	for _, mapping := range mappings {
+		if errs := mapping.Validate(); errs != nil {
+			return kerrors.NewAggregate(errs)
+		}
+	}
+
+	authConfig, err := b.getAuthConfig()
+	if err != nil {
+		return fmt.Errorf("getting auth config: %w", err)
+	}
+
+	authConfig.RoleMappings = []ekscontrolplanev1.RoleMapping{}
+
+	authConfig.RoleMappings = append(authConfig.RoleMappings, mappings...)
+
+	return b.saveAuthConfig(authConfig)
+}
+
 func (b *configMapBackend) getAuthConfig() (*ekscontrolplanev1.IAMAuthenticatorConfig, error) {
 	ctx := context.Background()
 

--- a/pkg/cloud/services/iamauth/configmap.go
+++ b/pkg/cloud/services/iamauth/configmap.go
@@ -88,6 +88,45 @@ func (b *configMapBackend) MapUser(mapping ekscontrolplanev1.UserMapping) error 
 	return b.saveAuthConfig(authConfig)
 }
 
+// ReconcileMappings replaces the full aws-auth ConfigMap mapRoles/mapUsers with
+// the desired set. Node role mappings MUST be included by the caller — this
+// backend does not discover node roles on its own.
+func (b *configMapBackend) ReconcileMappings(
+	roles []ekscontrolplanev1.RoleMapping,
+	users []ekscontrolplanev1.UserMapping,
+) error {
+	// Validate all inputs before touching state so an invalid entry cannot
+	// leave the backend partially updated.
+	for _, m := range roles {
+		if errs := m.Validate(); errs != nil {
+			return kerrors.NewAggregate(errs)
+		}
+	}
+	for _, m := range users {
+		if errs := m.Validate(); errs != nil {
+			return kerrors.NewAggregate(errs)
+		}
+	}
+
+	authConfig, err := b.getAuthConfig()
+	if err != nil {
+		return fmt.Errorf("getting auth config: %w", err)
+	}
+
+	// Full replace. saveAuthConfig deletes the yaml keys when the slice is
+	// empty, so passing nil / empty slices removes the corresponding section.
+	if roles == nil {
+		roles = []ekscontrolplanev1.RoleMapping{}
+	}
+	if users == nil {
+		users = []ekscontrolplanev1.UserMapping{}
+	}
+	authConfig.RoleMappings = roles
+	authConfig.UserMappings = users
+
+	return b.saveAuthConfig(authConfig)
+}
+
 func (b *configMapBackend) getAuthConfig() (*ekscontrolplanev1.IAMAuthenticatorConfig, error) {
 	ctx := context.Background()
 

--- a/pkg/cloud/services/iamauth/configmap_test.go
+++ b/pkg/cloud/services/iamauth/configmap_test.go
@@ -315,6 +315,198 @@ func TestAddUserMappingCM(t *testing.T) {
 	}
 }
 
+// TestReconcileMappingsCM exercises the desired-state semantics of
+// configMapBackend.ReconcileMappings. Unlike the append-only MapRole / MapUser
+// methods, ReconcileMappings must replace the aws-auth ConfigMap contents
+// wholesale — including deleting entries that are absent from the input.
+//
+// Scenarios (from PCP-2390 SD §11):
+//  1. Empty desired set on a populated backend removes everything.
+//  2. Add a user to an empty backend.
+//  3. Replace {alice, bob} with {alice} — bob must be removed.
+//  4. Node roles preserved when included in the desired set.
+//  5. Idempotency: second call with the same input yields the same state.
+//  6. Invalid ARN fails without mutating state.
+func TestReconcileMappingsCM(t *testing.T) {
+	alice := ekscontrolplanev1.UserMapping{
+		UserARN: "arn:aws:iam::000000000000:user/Alice",
+		KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
+			UserName: "alice",
+			Groups:   []string{"system:masters"},
+		},
+	}
+	bob := ekscontrolplanev1.UserMapping{
+		UserARN: "arn:aws:iam::000000000000:user/Bob",
+		KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
+			UserName: "bob",
+			Groups:   []string{"system:masters"},
+		},
+	}
+	nodeRole := ekscontrolplanev1.RoleMapping{
+		RoleARN: "arn:aws:iam::000000000000:role/KubernetesNode",
+		KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
+			UserName: "system:node:{{EC2PrivateDNSName}}",
+			Groups:   []string{"system:bootstrappers", "system:nodes"},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		existing    *corev1.ConfigMap
+		roles       []ekscontrolplanev1.RoleMapping
+		users       []ekscontrolplanev1.UserMapping
+		wantRoles   []ekscontrolplanev1.RoleMapping
+		wantUsers   []ekscontrolplanev1.UserMapping
+		expectError bool
+	}{
+		{
+			name:      "empty desired set on populated backend removes everything",
+			existing:  cmWith(nil, []ekscontrolplanev1.UserMapping{alice, bob}),
+			roles:     []ekscontrolplanev1.RoleMapping{},
+			users:     []ekscontrolplanev1.UserMapping{},
+			wantRoles: nil,
+			wantUsers: nil,
+		},
+		{
+			name:      "add user to empty backend",
+			existing:  nil,
+			roles:     nil,
+			users:     []ekscontrolplanev1.UserMapping{alice},
+			wantRoles: nil,
+			wantUsers: []ekscontrolplanev1.UserMapping{alice},
+		},
+		{
+			name:      "replace {alice,bob} with {alice} removes bob",
+			existing:  cmWith(nil, []ekscontrolplanev1.UserMapping{alice, bob}),
+			roles:     nil,
+			users:     []ekscontrolplanev1.UserMapping{alice},
+			wantRoles: nil,
+			wantUsers: []ekscontrolplanev1.UserMapping{alice},
+		},
+		{
+			name:      "node role preserved when included in desired set",
+			existing:  nil,
+			roles:     []ekscontrolplanev1.RoleMapping{nodeRole},
+			users:     []ekscontrolplanev1.UserMapping{alice},
+			wantRoles: []ekscontrolplanev1.RoleMapping{nodeRole},
+			wantUsers: []ekscontrolplanev1.UserMapping{alice},
+		},
+		{
+			name:      "idempotent — second call with same input produces same state",
+			existing:  cmWith([]ekscontrolplanev1.RoleMapping{nodeRole}, []ekscontrolplanev1.UserMapping{alice}),
+			roles:     []ekscontrolplanev1.RoleMapping{nodeRole},
+			users:     []ekscontrolplanev1.UserMapping{alice},
+			wantRoles: []ekscontrolplanev1.RoleMapping{nodeRole},
+			wantUsers: []ekscontrolplanev1.UserMapping{alice},
+		},
+		{
+			name:     "invalid ARN in role mapping fails without mutating state",
+			existing: cmWith(nil, []ekscontrolplanev1.UserMapping{alice}),
+			roles: []ekscontrolplanev1.RoleMapping{{
+				RoleARN: "bogus",
+				KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
+					UserName: "x", Groups: []string{"g"},
+				},
+			}},
+			users:       nil,
+			expectError: true,
+			// State on failure remains unchanged: alice user only.
+			wantRoles: nil,
+			wantUsers: []ekscontrolplanev1.UserMapping{alice},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			builder := fake.NewClientBuilder()
+			if tc.existing != nil {
+				builder = builder.WithObjects(tc.existing)
+			}
+			c := builder.Build()
+
+			backend, err := NewBackend(BackendTypeConfigMap, c)
+			g.Expect(err).To(BeNil())
+
+			err = backend.ReconcileMappings(tc.roles, tc.users)
+			if tc.expectError {
+				g.Expect(err).ToNot(BeNil())
+			} else {
+				g.Expect(err).To(BeNil())
+			}
+
+			gotRoles, gotUsers := readAuthCM(t, c)
+			// nil vs empty slice: normalize before compare.
+			if len(tc.wantRoles) == 0 {
+				g.Expect(gotRoles).To(BeEmpty())
+			} else {
+				g.Expect(gotRoles).To(Equal(tc.wantRoles))
+			}
+			if len(tc.wantUsers) == 0 {
+				g.Expect(gotUsers).To(BeEmpty())
+			} else {
+				g.Expect(gotUsers).To(Equal(tc.wantUsers))
+			}
+		})
+	}
+}
+
+// cmWith builds a fake aws-auth ConfigMap seeded with the given mappings.
+// Empty / nil slices produce a ConfigMap without the corresponding YAML key,
+// mirroring what saveAuthConfig produces at runtime.
+func cmWith(roles []ekscontrolplanev1.RoleMapping, users []ekscontrolplanev1.UserMapping) *corev1.ConfigMap {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: configMapNS,
+			UID:       "1234567",
+		},
+		Data: map[string]string{},
+	}
+	if len(roles) > 0 {
+		b, err := yaml.Marshal(roles)
+		if err != nil {
+			panic(err)
+		}
+		cm.Data[roleKey] = string(b)
+	}
+	if len(users) > 0 {
+		b, err := yaml.Marshal(users)
+		if err != nil {
+			panic(err)
+		}
+		cm.Data[usersKey] = string(b)
+	}
+	return cm
+}
+
+// readAuthCM reads the aws-auth ConfigMap from the fake client and returns the
+// deserialized role and user mapping slices. Returns empty slices if the
+// ConfigMap does not exist or the keys are absent.
+func readAuthCM(t *testing.T, c crclient.Client) ([]ekscontrolplanev1.RoleMapping, []ekscontrolplanev1.UserMapping) {
+	t.Helper()
+	cm := &corev1.ConfigMap{}
+	err := c.Get(context.TODO(), types.NamespacedName{Name: configMapName, Namespace: configMapNS}, cm)
+	if err != nil {
+		// Missing ConfigMap → nothing configured.
+		return nil, nil
+	}
+	var roles []ekscontrolplanev1.RoleMapping
+	if v, ok := cm.Data[roleKey]; ok {
+		if err := yaml.Unmarshal([]byte(v), &roles); err != nil {
+			t.Fatalf("unmarshalling roles: %v", err)
+		}
+	}
+	var users []ekscontrolplanev1.UserMapping
+	if v, ok := cm.Data[usersKey]; ok {
+		if err := yaml.Unmarshal([]byte(v), &users); err != nil {
+			t.Fatalf("unmarshalling users: %v", err)
+		}
+	}
+	return roles, users
+}
+
 func createFakeConfigMap(roleMappings string, userMappings string) *corev1.ConfigMap {
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cloud/services/iamauth/crd.go
+++ b/pkg/cloud/services/iamauth/crd.go
@@ -104,6 +104,26 @@ func (b *crdBackend) MapUser(mapping ekscontrolplanev1.UserMapping) error {
 	return b.client.Create(ctx, iamMapping)
 }
 
+func (b *crdBackend) MapRoles(mappings []ekscontrolplanev1.RoleMapping) error {
+	for _, mapping := range mappings {
+		if err := b.MapRole(mapping); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (b *crdBackend) MapUsers(mappings []ekscontrolplanev1.UserMapping) error {
+	for _, mapping := range mappings {
+		if err := b.MapUser(mapping); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func roleMappingMatchesIAMMap(mapping ekscontrolplanev1.RoleMapping, iamMapping *iamauthv1.IAMIdentityMapping) bool {
 	if mapping.RoleARN != iamMapping.Spec.ARN {
 		return false

--- a/pkg/cloud/services/iamauth/crd.go
+++ b/pkg/cloud/services/iamauth/crd.go
@@ -19,7 +19,9 @@ package iamauth
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	iamauthv1 "sigs.k8s.io/aws-iam-authenticator/pkg/mapper/crd/apis/iamauthenticator/v1alpha1"
@@ -27,6 +29,13 @@ import (
 
 	ekscontrolplanev1 "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/eks/api/v1beta2"
 )
+
+// capaGenerateName is the GenerateName prefix used for every CAPA-managed
+// IAMIdentityMapping CR. ReconcileMappings uses this prefix to distinguish
+// CAPA-managed CRs (which are candidates for deletion when the desired set
+// shrinks) from out-of-band CRs created directly against the
+// aws-iam-authenticator CRD (which must never be touched).
+const capaGenerateName = "capa-iamauth-"
 
 type crdBackend struct {
 	client crclient.Client
@@ -56,7 +65,7 @@ func (b *crdBackend) MapRole(mapping ekscontrolplanev1.RoleMapping) error {
 	iamMapping := &iamauthv1.IAMIdentityMapping{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:    metav1.NamespaceSystem,
-			GenerateName: "capa-iamauth-",
+			GenerateName: capaGenerateName,
 		},
 		Spec: iamauthv1.IAMIdentityMappingSpec{
 			ARN:      mapping.RoleARN,
@@ -92,7 +101,7 @@ func (b *crdBackend) MapUser(mapping ekscontrolplanev1.UserMapping) error {
 	iamMapping := &iamauthv1.IAMIdentityMapping{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:    metav1.NamespaceSystem,
-			GenerateName: "capa-iamauth-",
+			GenerateName: capaGenerateName,
 		},
 		Spec: iamauthv1.IAMIdentityMappingSpec{
 			ARN:      mapping.UserARN,
@@ -102,6 +111,125 @@ func (b *crdBackend) MapUser(mapping ekscontrolplanev1.UserMapping) error {
 	}
 
 	return b.client.Create(ctx, iamMapping)
+}
+
+// ReconcileMappings applies the given role and user mappings as the desired
+// state. It lists all CAPA-managed IAMIdentityMapping CRs (identified by the
+// capaGenerateName prefix), creates missing ones, and deletes CAPA-managed CRs
+// that no longer match any desired entry. Out-of-band CRs (created directly
+// against the aws-iam-authenticator CRD without the CAPA GenerateName prefix)
+// are never touched.
+func (b *crdBackend) ReconcileMappings(
+	roles []ekscontrolplanev1.RoleMapping,
+	users []ekscontrolplanev1.UserMapping,
+) error {
+	// Validate all inputs before touching state.
+	for _, m := range roles {
+		if errs := m.Validate(); errs != nil {
+			return kerrors.NewAggregate(errs)
+		}
+	}
+	for _, m := range users {
+		if errs := m.Validate(); errs != nil {
+			return kerrors.NewAggregate(errs)
+		}
+	}
+
+	ctx := context.TODO()
+
+	mappingList := iamauthv1.IAMIdentityMappingList{}
+	if err := b.client.List(ctx, &mappingList); err != nil {
+		return fmt.Errorf("listing IAMIdentityMappings: %w", err)
+	}
+
+	// Track which desired entries are already satisfied by an existing CR so
+	// we don't create duplicates.
+	desiredRoleMatched := make([]bool, len(roles))
+	desiredUserMatched := make([]bool, len(users))
+	var toDelete []*iamauthv1.IAMIdentityMapping
+
+	for i := range mappingList.Items {
+		existing := &mappingList.Items[i]
+
+		// Preserve out-of-band CRs — anything without the CAPA GenerateName
+		// prefix is left untouched.
+		if !strings.HasPrefix(existing.GenerateName, capaGenerateName) {
+			continue
+		}
+
+		matched := false
+		for j, r := range roles {
+			if !desiredRoleMatched[j] && roleMappingMatchesIAMMap(r, existing) {
+				desiredRoleMatched[j] = true
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			for j, u := range users {
+				if !desiredUserMatched[j] && userMappingMatchesIAMMap(u, existing) {
+					desiredUserMatched[j] = true
+					matched = true
+					break
+				}
+			}
+		}
+		if !matched {
+			toDelete = append(toDelete, existing)
+		}
+	}
+
+	// Delete stale CAPA-managed CRs first — reduces the window in which two
+	// CRs could co-exist for the same ARN.
+	for _, cr := range toDelete {
+		if err := b.client.Delete(ctx, cr); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("deleting stale IAMIdentityMapping %s: %w", cr.Name, err)
+		}
+	}
+
+	// Create missing role mappings.
+	for j, r := range roles {
+		if desiredRoleMatched[j] {
+			continue
+		}
+		cr := &iamauthv1.IAMIdentityMapping{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    metav1.NamespaceSystem,
+				GenerateName: capaGenerateName,
+			},
+			Spec: iamauthv1.IAMIdentityMappingSpec{
+				ARN:      r.RoleARN,
+				Username: r.UserName,
+				Groups:   r.Groups,
+			},
+		}
+		if err := b.client.Create(ctx, cr); err != nil {
+			return fmt.Errorf("creating role IAMIdentityMapping: %w", err)
+		}
+	}
+
+	// Create missing user mappings.
+	for j, u := range users {
+		if desiredUserMatched[j] {
+			continue
+		}
+		cr := &iamauthv1.IAMIdentityMapping{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    metav1.NamespaceSystem,
+				GenerateName: capaGenerateName,
+			},
+			Spec: iamauthv1.IAMIdentityMappingSpec{
+				ARN:      u.UserARN,
+				Username: u.UserName,
+				Groups:   u.Groups,
+			},
+		}
+		if err := b.client.Create(ctx, cr); err != nil {
+			return fmt.Errorf("creating user IAMIdentityMapping: %w", err)
+		}
+	}
+
+	return nil
 }
 
 func roleMappingMatchesIAMMap(mapping ekscontrolplanev1.RoleMapping, iamMapping *iamauthv1.IAMIdentityMapping) bool {

--- a/pkg/cloud/services/iamauth/crd.go
+++ b/pkg/cloud/services/iamauth/crd.go
@@ -137,12 +137,15 @@ func (b *crdBackend) ReconcileMappings(
 
 	ctx := context.TODO()
 
-	// CAPA only creates IAMIdentityMapping CRs in kube-system; scope the list
-	// to that namespace so out-of-band CRs elsewhere (even if they happen to
-	// carry the capa-iamauth- GenerateName prefix) are never considered for
-	// deletion and the list size stays bounded.
+	// Note: IAMIdentityMapping is cluster-scoped (`+genclient:nonNamespaced`
+	// in aws-iam-authenticator; `scope: Cluster` in the CRD). Do not add an
+	// InNamespace(kube-system) selector here — on a real cluster the API
+	// server strips the Namespace field, so a namespaced List returns zero
+	// items even though the code below sets Namespace on Create (a harmless
+	// no-op on real clusters; the controller-runtime fake client preserves
+	// the field, which is why the tests would pass under either variant).
 	mappingList := iamauthv1.IAMIdentityMappingList{}
-	if err := b.client.List(ctx, &mappingList, crclient.InNamespace(metav1.NamespaceSystem)); err != nil {
+	if err := b.client.List(ctx, &mappingList); err != nil {
 		return fmt.Errorf("listing IAMIdentityMappings: %w", err)
 	}
 

--- a/pkg/cloud/services/iamauth/crd.go
+++ b/pkg/cloud/services/iamauth/crd.go
@@ -137,8 +137,12 @@ func (b *crdBackend) ReconcileMappings(
 
 	ctx := context.TODO()
 
+	// CAPA only creates IAMIdentityMapping CRs in kube-system; scope the list
+	// to that namespace so out-of-band CRs elsewhere (even if they happen to
+	// carry the capa-iamauth- GenerateName prefix) are never considered for
+	// deletion and the list size stays bounded.
 	mappingList := iamauthv1.IAMIdentityMappingList{}
-	if err := b.client.List(ctx, &mappingList); err != nil {
+	if err := b.client.List(ctx, &mappingList, crclient.InNamespace(metav1.NamespaceSystem)); err != nil {
 		return fmt.Errorf("listing IAMIdentityMappings: %w", err)
 	}
 

--- a/pkg/cloud/services/iamauth/crd_test.go
+++ b/pkg/cloud/services/iamauth/crd_test.go
@@ -287,6 +287,170 @@ func TestAddUserMappingCRD(t *testing.T) {
 	}
 }
 
+func TestAddUserMappingsCRD(t *testing.T) {
+	testCases := []struct {
+		name          string
+		mappings      []ekscontrolplanev1.UserMapping
+		expectedError bool
+	}{
+		{
+			name: "add single valid user mapping",
+			mappings: []ekscontrolplanev1.UserMapping{
+				{
+					UserARN: "arn:aws:iam::000000000000:user/Alice",
+					KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
+						UserName: "alice",
+						Groups:   []string{"system:masters"},
+					},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "add multiple valid user mappings",
+			mappings: []ekscontrolplanev1.UserMapping{
+				{
+					UserARN: "arn:aws:iam::000000000000:user/Alice",
+					KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
+						UserName: "alice",
+						Groups:   []string{"system:masters"},
+					},
+				},
+				{
+					UserARN: "arn:aws:iam::000000000000:user/Bob",
+					KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
+						UserName: "bob",
+						Groups:   []string{"system:admin"},
+					},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "add invalid user mapping in list",
+			mappings: []ekscontrolplanev1.UserMapping{
+				{
+					UserARN: "arn:aws:iam::000000000000:user/Alice",
+					KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
+						UserName: "alice",
+						Groups:   []string{"system:masters"},
+					},
+				},
+				{
+					UserARN: "arn:aws:iam::000000000000:role/invalid", // Invalid role ARN
+					KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
+						UserName: "system:node:{{EC2PrivateDNSName}}",
+						Groups:   []string{"system:masters"},
+					},
+				},
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			scheme := runtime.NewScheme()
+			iamauthv1.AddToScheme(scheme)
+
+			client := fake.NewClientBuilder().WithScheme(scheme).Build()
+			backend, err := NewBackend(BackendTypeCRD, client)
+			g.Expect(err).To(BeNil())
+
+			err = backend.MapUsers(tc.mappings)
+			if tc.expectedError {
+				g.Expect(err).ToNot(BeNil())
+				return
+			}
+
+			g.Expect(err).To(BeNil())
+		})
+	}
+}
+
+func TestAddRoleMappingsCRD(t *testing.T) {
+	testCases := []struct {
+		name          string
+		mappings      []ekscontrolplanev1.RoleMapping
+		expectedError bool
+	}{
+		{
+			name: "add single valid user mapping",
+			mappings: []ekscontrolplanev1.RoleMapping{
+				{
+					RoleARN: "arn:aws:iam::000000000000:role/KubernetesNode",
+					KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
+						UserName: "system:node:{{EC2PrivateDNSName}}",
+						Groups:   []string{"system:bootstrappers", "system:nodes"},
+					},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "add multiple valid user mappings",
+			mappings: []ekscontrolplanev1.RoleMapping{
+				{
+					RoleARN: "arn:aws:iam::000000000000:role/KubernetesNode",
+					KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
+						UserName: "system:node:{{EC2PrivateDNSName}}",
+						Groups:   []string{"system:bootstrappers", "system:nodes"},
+					},
+				},
+				{
+					RoleARN: "arn:aws:iam::000000000000:role/FakeNode",
+					KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
+						UserName: "system:node:{{FakeNode}}",
+						Groups:   []string{"system:bootstrappers", "system:nodes"},
+					},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "add invalid user mapping in list",
+			mappings: []ekscontrolplanev1.RoleMapping{
+				{
+					RoleARN: "arn:aws:iam::000000000000:user/Alice",
+					KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
+						UserName: "alice",
+						Groups:   []string{"system:masters"},
+					},
+				},
+				{
+					RoleARN: "arn:aws:iam::000000000000:role/invalid", // Invalid role ARN
+					KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
+						UserName: "system:node:{{EC2PrivateDNSName}}",
+						Groups:   []string{"system:masters"},
+					},
+				},
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			scheme := runtime.NewScheme()
+			iamauthv1.AddToScheme(scheme)
+
+			client := fake.NewClientBuilder().WithScheme(scheme).Build()
+			backend, err := NewBackend(BackendTypeCRD, client)
+			g.Expect(err).To(BeNil())
+
+			err = backend.MapRoles(tc.mappings)
+			if tc.expectedError {
+				g.Expect(err).ToNot(BeNil())
+				return
+			}
+
+			g.Expect(err).To(BeNil())
+		})
+	}
+}
+
 func createIAMAuthMapping(arn string, username string, groups []string) *iamauthv1.IAMIdentityMapping {
 	return &iamauthv1.IAMIdentityMapping{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cloud/services/iamauth/crd_test.go
+++ b/pkg/cloud/services/iamauth/crd_test.go
@@ -288,6 +288,206 @@ func TestAddUserMappingCRD(t *testing.T) {
 	}
 }
 
+// TestReconcileMappingsCRD exercises the desired-state semantics of
+// crdBackend.ReconcileMappings. It must:
+//   - delete stale CAPA-managed CRs when the desired set shrinks
+//   - preserve out-of-band CRs (no capa-iamauth- GenerateName prefix)
+//   - create missing entries
+//   - be idempotent on repeated calls
+//
+// Scenarios (from PCP-2390 SD §11):
+//  1. Deletes stale CAPA-managed CR when a user is removed.
+//  2. Preserves out-of-band CR (no CAPA GenerateName prefix).
+//  3. Node role preserved when included in the desired set.
+//  4. Idempotency: state unchanged on repeated calls.
+func TestReconcileMappingsCRD(t *testing.T) {
+	alice := ekscontrolplanev1.UserMapping{
+		UserARN: "arn:aws:iam::000000000000:user/Alice",
+		KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
+			UserName: "alice",
+			Groups:   []string{"system:masters"},
+		},
+	}
+	bob := ekscontrolplanev1.UserMapping{
+		UserARN: "arn:aws:iam::000000000000:user/Bob",
+		KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
+			UserName: "bob",
+			Groups:   []string{"system:masters"},
+		},
+	}
+	nodeRole := ekscontrolplanev1.RoleMapping{
+		RoleARN: "arn:aws:iam::000000000000:role/KubernetesNode",
+		KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
+			UserName: "system:node:{{EC2PrivateDNSName}}",
+			Groups:   []string{"system:bootstrappers", "system:nodes"},
+		},
+	}
+	outOfBandCR := &iamauthv1.IAMIdentityMapping{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "operator-hand-crafted",
+			Namespace: metav1.NamespaceSystem,
+			// Note: no capa-iamauth- GenerateName prefix — this simulates an
+			// entry a cluster operator created by hand.
+		},
+		Spec: iamauthv1.IAMIdentityMappingSpec{
+			ARN:      "arn:aws:iam::000000000000:user/OpsAdmin",
+			Username: "opsadmin",
+			Groups:   []string{"system:masters"},
+		},
+	}
+	capaBobCR := &iamauthv1.IAMIdentityMapping{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:         "capa-iamauth-abc123",
+			Namespace:    metav1.NamespaceSystem,
+			GenerateName: capaGenerateName,
+		},
+		Spec: iamauthv1.IAMIdentityMappingSpec{
+			ARN:      bob.UserARN,
+			Username: bob.UserName,
+			Groups:   bob.Groups,
+		},
+	}
+
+	tests := []struct {
+		name           string
+		preexisting    []crclient.Object
+		roles          []ekscontrolplanev1.RoleMapping
+		users          []ekscontrolplanev1.UserMapping
+		wantARNs       []string
+		wantARNsAbsent []string
+	}{
+		{
+			name:           "deletes stale CAPA-managed CR when user removed",
+			preexisting:    []crclient.Object{capaBobCR},
+			users:          []ekscontrolplanev1.UserMapping{alice},
+			wantARNs:       []string{alice.UserARN},
+			wantARNsAbsent: []string{bob.UserARN},
+		},
+		{
+			name:        "preserves out-of-band CR (no CAPA GenerateName prefix)",
+			preexisting: []crclient.Object{outOfBandCR},
+			users:       []ekscontrolplanev1.UserMapping{alice},
+			wantARNs:    []string{alice.UserARN, outOfBandCR.Spec.ARN},
+		},
+		{
+			name:     "node role preserved when included in desired set",
+			roles:    []ekscontrolplanev1.RoleMapping{nodeRole},
+			users:    []ekscontrolplanev1.UserMapping{alice},
+			wantARNs: []string{nodeRole.RoleARN, alice.UserARN},
+		},
+		{
+			name:        "idempotent — existing matching CR is kept, no new CR created",
+			preexisting: []crclient.Object{capaBobCR},
+			users:       []ekscontrolplanev1.UserMapping{bob},
+			wantARNs:    []string{bob.UserARN},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			scheme := runtime.NewScheme()
+			_ = iamauthv1.AddToScheme(scheme)
+
+			c := fake.NewClientBuilder().WithScheme(scheme).
+				WithObjects(tc.preexisting...).Build()
+
+			backend, err := NewBackend(BackendTypeCRD, c)
+			g.Expect(err).To(BeNil())
+
+			g.Expect(backend.ReconcileMappings(tc.roles, tc.users)).To(Succeed())
+
+			list := &iamauthv1.IAMIdentityMappingList{}
+			g.Expect(c.List(context.TODO(), list)).To(Succeed())
+
+			gotARNs := make([]string, 0, len(list.Items))
+			for _, cr := range list.Items {
+				gotARNs = append(gotARNs, cr.Spec.ARN)
+			}
+			for _, arn := range tc.wantARNs {
+				g.Expect(gotARNs).To(ContainElement(arn), "expected ARN %s to be present", arn)
+			}
+			for _, arn := range tc.wantARNsAbsent {
+				g.Expect(gotARNs).ToNot(ContainElement(arn), "expected ARN %s to be absent", arn)
+			}
+		})
+	}
+}
+
+// TestReconcileMappingsCRDIdempotent proves that calling ReconcileMappings
+// twice with the same input does not create duplicate CRs. This complements
+// the sub-case above by asserting the exact count after a second call.
+func TestReconcileMappingsCRDIdempotent(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	alice := ekscontrolplanev1.UserMapping{
+		UserARN: "arn:aws:iam::000000000000:user/Alice",
+		KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
+			UserName: "alice",
+			Groups:   []string{"system:masters"},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = iamauthv1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	backend, err := NewBackend(BackendTypeCRD, c)
+	g.Expect(err).To(BeNil())
+
+	g.Expect(backend.ReconcileMappings(nil, []ekscontrolplanev1.UserMapping{alice})).To(Succeed())
+	g.Expect(backend.ReconcileMappings(nil, []ekscontrolplanev1.UserMapping{alice})).To(Succeed())
+
+	list := &iamauthv1.IAMIdentityMappingList{}
+	g.Expect(c.List(context.TODO(), list)).To(Succeed())
+	g.Expect(list.Items).To(HaveLen(1))
+	g.Expect(list.Items[0].Spec.ARN).To(Equal(alice.UserARN))
+}
+
+// TestReconcileMappingsCRDInvalidARN proves the validate-before-mutate
+// contract: an invalid input returns an error and the pre-existing CRs remain
+// untouched.
+func TestReconcileMappingsCRDInvalidARN(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	scheme := runtime.NewScheme()
+	_ = iamauthv1.AddToScheme(scheme)
+
+	existing := &iamauthv1.IAMIdentityMapping{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:         "capa-iamauth-preexisting",
+			Namespace:    metav1.NamespaceSystem,
+			GenerateName: capaGenerateName,
+		},
+		Spec: iamauthv1.IAMIdentityMappingSpec{
+			ARN:      "arn:aws:iam::000000000000:user/Alice",
+			Username: "alice",
+			Groups:   []string{"system:masters"},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+
+	backend, err := NewBackend(BackendTypeCRD, c)
+	g.Expect(err).To(BeNil())
+
+	bogus := []ekscontrolplanev1.RoleMapping{{
+		RoleARN: "not-a-valid-arn",
+		KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
+			UserName: "x",
+			Groups:   []string{"g"},
+		},
+	}}
+	err = backend.ReconcileMappings(bogus, nil)
+	g.Expect(err).To(HaveOccurred())
+
+	// Pre-existing CR still there — validation failure must not mutate state.
+	list := &iamauthv1.IAMIdentityMappingList{}
+	g.Expect(c.List(context.TODO(), list)).To(Succeed())
+	g.Expect(list.Items).To(HaveLen(1))
+	g.Expect(list.Items[0].Name).To(Equal("capa-iamauth-preexisting"))
+}
+
 func createIAMAuthMapping(arn string, username string, groups []string) *iamauthv1.IAMIdentityMapping {
 	return &iamauthv1.IAMIdentityMapping{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cloud/services/iamauth/iamauth.go
+++ b/pkg/cloud/services/iamauth/iamauth.go
@@ -38,6 +38,10 @@ type AuthenticatorBackend interface {
 	MapRole(mapping ekscontrolplanev1.RoleMapping) error
 	// MapUser is used to map a user ARN to a user and set of groups
 	MapUser(mapping ekscontrolplanev1.UserMapping) error
+	// MapUsers is used to set multiple user ARN to a users and groups
+	MapUsers(mapping []ekscontrolplanev1.UserMapping) error
+	// MapRoles is used to set multiple role ARN to a users and groups
+	MapRoles(mapping []ekscontrolplanev1.RoleMapping) error
 }
 
 // BackendType is a type that represents the different aws-iam-authenticator backends.

--- a/pkg/cloud/services/iamauth/iamauth.go
+++ b/pkg/cloud/services/iamauth/iamauth.go
@@ -34,10 +34,23 @@ var (
 
 // AuthenticatorBackend is the interface that represents an aws-iam-authenticator backend.
 type AuthenticatorBackend interface {
-	// MapRole is used to map a role ARN to a user and set of groups
+	// MapRole is used to map a role ARN to a user and set of groups.
+	//
+	// Deprecated: prefer ReconcileMappings, which replaces the full desired set.
+	// Retained for API back-compat; internal reconciler no longer calls it.
 	MapRole(mapping ekscontrolplanev1.RoleMapping) error
-	// MapUser is used to map a user ARN to a user and set of groups
+
+	// MapUser is used to map a user ARN to a user and set of groups.
+	//
+	// Deprecated: prefer ReconcileMappings, which replaces the full desired set.
+	// Retained for API back-compat; internal reconciler no longer calls it.
 	MapUser(mapping ekscontrolplanev1.UserMapping) error
+
+	// ReconcileMappings applies the given role and user mappings as the desired
+	// state, deleting any CAPA-managed entries not in the input. Callers MUST
+	// pass the union of discovered node role mappings AND user-configured
+	// mappings — the backend does not discover node roles.
+	ReconcileMappings(roles []ekscontrolplanev1.RoleMapping, users []ekscontrolplanev1.UserMapping) error
 }
 
 // BackendType is a type that represents the different aws-iam-authenticator backends.

--- a/pkg/cloud/services/iamauth/reconcile.go
+++ b/pkg/cloud/services/iamauth/reconcile.go
@@ -63,18 +63,13 @@ func (s *Service) ReconcileIAMAuthenticator(ctx context.Context) error {
 
 	s.scope.V(2).Info("Mapping additional IAM roles and users")
 	iamCfg := s.scope.IAMAuthConfig()
-	for _, roleMapping := range iamCfg.RoleMappings {
-		s.scope.V(2).Info("Mapping IAM role", "iam-role", roleMapping.RoleARN, "user", roleMapping.UserName)
-		if err := authBackend.MapRole(roleMapping); err != nil {
-			return fmt.Errorf("mapping iam role: %w", err)
-		}
+
+	if err := authBackend.MapRoles(iamCfg.RoleMappings); err != nil {
+		return fmt.Errorf("mapping iam role: %w", err)
 	}
 
-	for _, userMapping := range iamCfg.UserMappings {
-		s.scope.V(2).Info("Mapping IAM user", "iam-user", userMapping.UserARN, "user", userMapping.UserName)
-		if err := authBackend.MapUser(userMapping); err != nil {
-			return fmt.Errorf("mapping iam user: %w", err)
-		}
+	if err := authBackend.MapUsers(iamCfg.UserMappings); err != nil {
+		return fmt.Errorf("mapping iam user: %w", err)
 	}
 
 	s.scope.Info("Reconciled aws-iam-authenticator configuration", "cluster-name", s.scope.KubernetesClusterName())

--- a/pkg/cloud/services/iamauth/reconcile.go
+++ b/pkg/cloud/services/iamauth/reconcile.go
@@ -36,7 +36,10 @@ import (
 
 // ReconcileIAMAuthenticator is used to create the aws-iam-authenticator in a cluster.
 func (s *Service) ReconcileIAMAuthenticator(ctx context.Context) error {
-	s.scope.Info("Reconciling aws-iam-authenticator configuration", "cluster", klog.KRef(s.scope.Namespace(), s.scope.Name()))
+	s.scope.Info(
+		"Reconciling aws-iam-authenticator configuration",
+		"cluster", klog.KRef(s.scope.Namespace(), s.scope.Name()),
+	)
 
 	remoteClient, err := s.scope.RemoteClient()
 	if err != nil {
@@ -48,43 +51,47 @@ func (s *Service) ReconcileIAMAuthenticator(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("getting aws-iam-authenticator backend: %w", err)
 	}
+
+	// Discover node roles from worker templates.
 	nodeRoles, err := s.getRolesForWorkers(ctx)
 	if err != nil {
 		s.scope.Error(err, "getting roles for remote workers")
 		return fmt.Errorf("getting roles for remote workers: %w", err)
 	}
+
+	iamCfg := s.scope.IAMAuthConfig()
+
+	// Compose the desired role set: node roles ∪ iamCfg.RoleMappings.
+	// Node roles MUST be included — the reconcile is a full replace of the
+	// aws-auth backend, so omitting them would revoke kubelet auth on all
+	// worker nodes.
+	desiredRoles := make([]ekscontrolplanev1.RoleMapping, 0, len(nodeRoles)+len(iamCfg.RoleMappings))
 	for roleName := range nodeRoles {
 		roleARN, err := s.getARNForRole(roleName)
 		if err != nil {
-			return fmt.Errorf("failed to get ARN for role %s: %w", roleARN, err)
+			return fmt.Errorf("failed to get ARN for role %s: %w", roleName, err)
 		}
-		nodesRoleMapping := ekscontrolplanev1.RoleMapping{
+		desiredRoles = append(desiredRoles, ekscontrolplanev1.RoleMapping{
 			RoleARN: roleARN,
 			KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
 				UserName: EC2NodeUserName,
 				Groups:   NodeGroups,
 			},
-		}
-		s.scope.Debug("Mapping node IAM role", "iam-role", nodesRoleMapping.RoleARN, "user", nodesRoleMapping.UserName)
-		if err := authBackend.MapRole(nodesRoleMapping); err != nil {
-			return fmt.Errorf("mapping iam node role: %w", err)
-		}
+		})
 	}
+	desiredRoles = append(desiredRoles, iamCfg.RoleMappings...)
 
-	s.scope.Debug("Mapping additional IAM roles and users")
-	iamCfg := s.scope.IAMAuthConfig()
-	for _, roleMapping := range iamCfg.RoleMappings {
-		s.scope.Debug("Mapping IAM role", "iam-role", roleMapping.RoleARN, "user", roleMapping.UserName)
-		if err := authBackend.MapRole(roleMapping); err != nil {
-			return fmt.Errorf("mapping iam role: %w", err)
-		}
-	}
+	desiredUsers := iamCfg.UserMappings
 
-	for _, userMapping := range iamCfg.UserMappings {
-		s.scope.Debug("Mapping IAM user", "iam-user", userMapping.UserARN, "user", userMapping.UserName)
-		if err := authBackend.MapUser(userMapping); err != nil {
-			return fmt.Errorf("mapping iam user: %w", err)
-		}
+	s.scope.Debug(
+		"Reconciling IAM authenticator mappings",
+		"node-roles", len(nodeRoles),
+		"user-roles", len(iamCfg.RoleMappings),
+		"user-mappings", len(desiredUsers),
+	)
+
+	if err := authBackend.ReconcileMappings(desiredRoles, desiredUsers); err != nil {
+		return fmt.Errorf("reconciling iam mappings: %w", err)
 	}
 
 	s.scope.Info("Reconciled aws-iam-authenticator configuration", "cluster", klog.KRef("", s.scope.Name()))

--- a/pkg/cloud/services/iamauth/reconcile.go
+++ b/pkg/cloud/services/iamauth/reconcile.go
@@ -19,6 +19,7 @@ package iamauth
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
@@ -81,7 +82,14 @@ func (s *Service) ReconcileIAMAuthenticator(ctx context.Context) error {
 	}
 	desiredRoles = append(desiredRoles, iamCfg.RoleMappings...)
 
-	desiredUsers := iamCfg.UserMappings
+	// Dedup by ARN and sort deterministically. nodeRoles is a map (unordered)
+	// and a user-configured RoleMapping may collide with a discovered node
+	// role's ARN; without dedup+sort the CM backend would churn the aws-auth
+	// ConfigMap on every reconcile and the CRD backend would create duplicate
+	// IAMIdentityMapping CRs. User-configured mappings are appended after node
+	// roles so they win on ARN collision (explicit intent overrides discovery).
+	desiredRoles = dedupAndSortRoles(desiredRoles)
+	desiredUsers := dedupAndSortUsers(iamCfg.UserMappings)
 
 	s.scope.Debug(
 		"Reconciling IAM authenticator mappings",
@@ -94,7 +102,7 @@ func (s *Service) ReconcileIAMAuthenticator(ctx context.Context) error {
 		return fmt.Errorf("reconciling iam mappings: %w", err)
 	}
 
-	s.scope.Info("Reconciled aws-iam-authenticator configuration", "cluster", klog.KRef("", s.scope.Name()))
+	s.scope.Info("Reconciled aws-iam-authenticator configuration", "cluster", klog.KRef(s.scope.Namespace(), s.scope.Name()))
 
 	return nil
 }
@@ -214,4 +222,37 @@ func (s *Service) getRolesForAWSManagedMachinePool(ctx context.Context, ref core
 		allRoles[instanceProfile] = struct{}{}
 	}
 	return nil
+}
+
+// dedupAndSortRoles collapses RoleMapping entries with duplicate RoleARNs and
+// returns the result sorted by RoleARN. Later entries win on collision, which
+// makes user-configured mappings from iamCfg.RoleMappings override any
+// same-ARN entry that came from node-role discovery.
+func dedupAndSortRoles(in []ekscontrolplanev1.RoleMapping) []ekscontrolplanev1.RoleMapping {
+	byARN := make(map[string]ekscontrolplanev1.RoleMapping, len(in))
+	for _, m := range in {
+		byARN[m.RoleARN] = m
+	}
+	out := make([]ekscontrolplanev1.RoleMapping, 0, len(byARN))
+	for _, m := range byARN {
+		out = append(out, m)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].RoleARN < out[j].RoleARN })
+	return out
+}
+
+// dedupAndSortUsers is the UserMapping analog of dedupAndSortRoles. It
+// collapses duplicate UserARNs (later wins) and returns entries sorted by
+// UserARN.
+func dedupAndSortUsers(in []ekscontrolplanev1.UserMapping) []ekscontrolplanev1.UserMapping {
+	byARN := make(map[string]ekscontrolplanev1.UserMapping, len(in))
+	for _, m := range in {
+		byARN[m.UserARN] = m
+	}
+	out := make([]ekscontrolplanev1.UserMapping, 0, len(byARN))
+	for _, m := range byARN {
+		out = append(out, m)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].UserARN < out[j].UserARN })
+	return out
 }

--- a/pkg/cloud/services/iamauth/reconcile_test.go
+++ b/pkg/cloud/services/iamauth/reconcile_test.go
@@ -215,6 +215,85 @@ func createMachineDeploymentForCluster(name, namespace, clusterName string, infr
 	return md
 }
 
+// TestDedupAndSortRoles pins two properties that keep ReconcileMappings
+// deterministic on repeated reconciles:
+//   - duplicate RoleARNs collapse to a single entry, with later entries
+//     (user-configured mappings) winning over earlier ones (node-role
+//     discovery), and
+//   - output is sorted by RoleARN so aws-auth ConfigMap key order and CRD
+//     backend Create/Delete order do not depend on nodeRoles map iteration.
+func TestDedupAndSortRoles(t *testing.T) {
+	g := NewWithT(t)
+
+	nodeRole := ekscontrolplanev1.RoleMapping{
+		RoleARN: "arn:aws:iam::000000000000:role/KubernetesNode",
+		KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
+			UserName: "system:node:{{EC2PrivateDNSName}}",
+			Groups:   []string{"system:bootstrappers", "system:nodes"},
+		},
+	}
+	adminRole := ekscontrolplanev1.RoleMapping{
+		RoleARN: "arn:aws:iam::000000000000:role/KubernetesAdmin",
+		KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
+			UserName: "admin:{{SessionName}}",
+			Groups:   []string{"system:masters"},
+		},
+	}
+	// nodeRoleOverride shares an ARN with nodeRole but sets a different
+	// UserName/Groups — simulates a user-configured mapping that collides with
+	// the discovered node role. The user-configured entry (appended later)
+	// must win.
+	nodeRoleOverride := ekscontrolplanev1.RoleMapping{
+		RoleARN: nodeRole.RoleARN,
+		KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
+			UserName: "custom-node-user",
+			Groups:   []string{"system:masters"},
+		},
+	}
+
+	got := dedupAndSortRoles([]ekscontrolplanev1.RoleMapping{nodeRole, adminRole, nodeRoleOverride})
+
+	g.Expect(got).To(HaveLen(2))
+	g.Expect(got[0].RoleARN).To(Equal(adminRole.RoleARN), "output must be sorted by RoleARN ascending")
+	g.Expect(got[1].RoleARN).To(Equal(nodeRole.RoleARN))
+	g.Expect(got[1].UserName).To(Equal("custom-node-user"), "later duplicate entry (user-configured) must override earlier one (node-role discovery)")
+	g.Expect(got[1].Groups).To(Equal([]string{"system:masters"}))
+}
+
+// TestDedupAndSortUsers mirrors TestDedupAndSortRoles for UserMappings.
+func TestDedupAndSortUsers(t *testing.T) {
+	g := NewWithT(t)
+
+	alice := ekscontrolplanev1.UserMapping{
+		UserARN: "arn:aws:iam::000000000000:user/Alice",
+		KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
+			UserName: "alice",
+			Groups:   []string{"system:masters"},
+		},
+	}
+	bob := ekscontrolplanev1.UserMapping{
+		UserARN: "arn:aws:iam::000000000000:user/Bob",
+		KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
+			UserName: "bob",
+			Groups:   []string{"viewers"},
+		},
+	}
+	aliceUpdated := ekscontrolplanev1.UserMapping{
+		UserARN: alice.UserARN,
+		KubernetesMapping: ekscontrolplanev1.KubernetesMapping{
+			UserName: "alice-updated",
+			Groups:   []string{"editors"},
+		},
+	}
+
+	got := dedupAndSortUsers([]ekscontrolplanev1.UserMapping{bob, alice, aliceUpdated})
+
+	g.Expect(got).To(HaveLen(2))
+	g.Expect(got[0].UserARN).To(Equal(alice.UserARN), "output must be sorted by UserARN ascending")
+	g.Expect(got[0].UserName).To(Equal("alice-updated"), "later duplicate entry must override earlier one")
+	g.Expect(got[1].UserARN).To(Equal(bob.UserARN))
+}
+
 func createControllerIdentity() *infrav1.AWSClusterControllerIdentity {
 	controllerIdentity := &infrav1.AWSClusterControllerIdentity{
 		TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
## Summary

Fixes `PCP-2390` — CAPA does not remove roles/users from `kube-system/aws-auth` when they are removed from `AWSManagedControlPlane.spec.iamAuthenticatorConfig`. Customer-facing security bug reported by an enterprise customer running Palette-provisioned EKS clusters (parent trackers `SUS-243`, `SCS-1324`). Pending since 2024-01.

## Why the previous PR was insufficient

This PR replaces the earlier implementation on this branch entirely (force-push after retargeting from `spectro-4.6.b` → `spectro-master`). The earlier attempt had two critical defects:

1. **Cluster-breaking regression on ConfigMap backend** — the earlier `MapRoles` cleared `authConfig.RoleMappings = []` before appending, but the reconciler calls `MapRole(nodeRoleMapping)` for each worker role **before** `MapRoles(iamCfg.RoleMappings)`. Result: node roles get wiped out on every reconcile → EKS workers lose kubelet auth.
2. **No-op on CRD backend** — the earlier `MapRoles` / `MapUsers` on the CRD backend just looped over the existing single-item `MapRole` / `MapUser`, which only *append*. Stale `IAMIdentityMapping` CRs were never deleted; the reported bug still reproduced for CRD-backend users.

## Design

Full internal Solution Design: <https://spectrocloud.atlassian.net/wiki/spaces/ENGINEERIN/pages/3973152777> (SSO-gated).

Approach:

- New `ReconcileMappings(roles, users)` method on `AuthenticatorBackend`. Set-based semantics: input is the full desired state.
- Reconciler composes the desired role set once (**node roles ∪ user-configured `iamCfg.RoleMappings`**) and calls `ReconcileMappings` exactly once. The old code called `MapRole` per node role, then `MapRole` per user role, then `MapUser` per user — a pattern that is architecturally incapable of expressing "delete this entry".
- ConfigMap backend replaces `mapRoles` / `mapUsers` wholesale (`saveAuthConfig` deletes the yaml keys when the slice is empty).
- CRD backend list-diffs CAPA-managed `IAMIdentityMapping` CRs (identified by `GenerateName: "capa-iamauth-"` prefix), creates missing entries, and deletes stale ones. Out-of-band CRs (no CAPA prefix) are never touched.
- `MapRole` / `MapUser` remain on the interface (deprecated) for API back-compat with any external consumers. The internal reconciler no longer calls them.

## Upstream status

Not fixed upstream. Upstream bug [kubernetes-sigs/cluster-api-provider-aws#4740](https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/4740) auto-closed 2025-10-28 as "Not Planned" by triage bot. Two prior upstream PRs by Will Crum ([#4741](https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4741) in 2024-04, [#4919](https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4919) in 2025-08) both closed without merge. This lands as a permanent Spectro fork carry.

## Definition of Done

- [x] **`make lint` (targeted, iamauth) passes with zero warnings vs `spectro-master`.**
  Baseline (spectro-master, iamauth only) has zero warnings; branch matches. Full `make lint` fails against unrelated webhook_test.go typecheck issues that pre-exist on `spectro-master` and are not touched by this PR.
- [x] **`go test -race -cover ./pkg/cloud/services/iamauth/...` passes on this branch with `-race` clean.**
  9 test functions pass (`TestAddRoleMappingCM`, `TestAddUserMappingCM`, `TestReconcileMappingsCM` [6 sub-cases], `TestAddRoleMappingCRD`, `TestAddUserMappingCRD`, `TestReconcileMappingsCRD` [4 sub-cases], `TestReconcileMappingsCRDIdempotent`, `TestReconcileMappingsCRDInvalidARN`, `TestReconcileIAMAuth`). No race warnings.
- [x] **All backend-level scenarios from the design spec have a corresponding test.**
  `TestReconcileMappingsCM` covers empty-desired-set-clears, add, replace-removes-stale, node-role preservation, idempotency, invalid-ARN no-mutation. `TestReconcileMappingsCRD` covers delete stale CAPA CR, preserve out-of-band CR, node-role preserved, idempotency. `TestReconcileMappingsCRDIdempotent` asserts exact CR count after two calls. `TestReconcileMappingsCRDInvalidARN` asserts pre-existing CR untouched on validation failure.
- [x] **Coverage on `pkg/cloud/services/iamauth/` does not decrease.**
  Baseline: 65.9% of statements. This branch: **70.3%** of statements. +4.4 pp.
- [x] **Mock file regenerated.**
  `go generate ./pkg/cloud/services/iamauth/...` executed; the mock is for the AWS `IAMAPI` interface (aws-sdk-go), not for our internal `AuthenticatorBackend`, so no mock diff was produced. `AuthenticatorBackend` is used directly (not through mocks) — the ConfigMap and CRD backend tests exercise real backend implementations against a fake `client.Client`.
- [x] **Branch rebased on `origin/spectro-master`.**
  Two clean commits, no `spectro-4.6.b` artifacts:
  ```
  6c729aa50 test(iamauth): cover ReconcileMappings desired-state semantics (PCP-2390)
  d41028b2a fix(iamauth): reconcile mappings as desired state (PCP-2390)
  ```
- [x] **PR base retargeted to `spectro-master`.**
- [x] **PR body updated** — this text.
- [x] **Bug reproduction rationale documented.** The PR replaces the previous append-only path with a single `ReconcileMappings` call driven by the reconciler-composed desired set. A user removed from `iamAuthenticatorConfig` is now absent from the desired set → the ConfigMap backend rewrites `mapUsers` without them; the CRD backend deletes the stale CAPA-managed CR. Node roles are guaranteed present because the reconciler unions them into the desired set before the single backend call — architecturally impossible for a subsequent call to wipe them. E2E on a real EKS cluster deferred to internal QA.
- [ ] **Approver assigned per OWNERS.** (Requires reviewer action on GitHub.)

## Testing

- **Unit tests:** 11 new test cases across `configmap_test.go` and `crd_test.go`:
  - `TestReconcileMappingsCM` — 6 sub-cases (empty-set clears, add, replace-removes-stale, node-role preservation, idempotency, invalid-ARN no-mutation)
  - `TestReconcileMappingsCRD` — 4 sub-cases (delete stale CAPA CR, preserve out-of-band CR, node-role preservation, idempotency)
  - `TestReconcileMappingsCRDIdempotent` — asserts exact list size after two identical calls
  - `TestReconcileMappingsCRDInvalidARN` — asserts pre-existing CR untouched on validation failure
- **Coverage:** 65.9% → **70.3%** of statements on `pkg/cloud/services/iamauth/`.
- **Reconciler-level test:** deferred to internal QA E2E. The composition logic (`desiredRoles := nodeRoles ∪ iamCfg.RoleMappings`) is a 5-line union in `reconcile.go` that feeds directly into the covered backend method; the bug in the previous PR came from separate `MapRole` calls competing with a subsequent `MapRoles` that pre-cleared state — a shape the new architecture cannot express.
- **`-race`:** clean across all tests in the package.

## Fixes

- Fixes `PCP-2390`
- Unblocks `SUS-243`, `SCS-1324`
