### PR TITLE
PCP-2735: EKS cluster deletion stuck with error failed to delete OIDC provider

### DIFF
--- a/pkg/cloud/services/eks/oidc.go
+++ b/pkg/cloud/services/eks/oidc.go
@@ -36,6 +36,13 @@ import (
 	"sigs.k8s.io/cluster-api/controllers/remote"
 )
 
+const (
+	// OidcProviderArnAnnotation set/unset this annotation to managed control plane.
+	// This is required in case of force pivot control plane status do not have ARN in status.
+	// In that cases annotation will be used to delete oidc resource.
+	OidcProviderArnAnnotation = "aws.spectrocloud.com/oidcProviderArn"
+)
+
 func (s *Service) reconcileOIDCProvider(cluster *eks.Cluster) error {
 	if !s.scope.ControlPlane.Spec.AssociateOIDCProvider {
 		return nil
@@ -141,7 +148,7 @@ func (s *Service) reconcileTrustPolicy() error {
 
 func (s *Service) deleteOIDCProvider() error {
 	annotations := s.scope.ControlPlane.GetAnnotations()
-	arn := annotations["aws.spectrocloud.com/oidcProviderArn"]
+	arn := annotations[OidcProviderArnAnnotation]
 
 	if arn == "" {
 		arn = s.scope.ControlPlane.Status.OIDCProvider.ARN
@@ -161,7 +168,7 @@ func (s *Service) deleteOIDCProvider() error {
 		return errors.Wrap(err, "failed to update control plane with OIDC provider ARN")
 	}
 
-	annotations["aws.spectrocloud.com/oidcProviderArn"] = ""
+	annotations[OidcProviderArnAnnotation] = ""
 	s.scope.ControlPlane.SetAnnotations(annotations)
 
 	return nil

--- a/pkg/cloud/services/eks/oidc.go
+++ b/pkg/cloud/services/eks/oidc.go
@@ -147,10 +147,15 @@ func (s *Service) reconcileTrustPolicy() error {
 }
 
 func (s *Service) deleteOIDCProvider() error {
+
+	// In case of force pivot managed control plane do not have ARN in status, that lead to oidcProvider not getting cleaned up during delete.
+	// OidcProviderArnAnnotation will be used to avoid it.
+
 	annotations := s.scope.ControlPlane.GetAnnotations()
 	arn := annotations[OidcProviderArnAnnotation]
 
 	if arn == "" {
+		// Upgrade support for cluster without OidcProviderArnAnnotation set
 		arn = s.scope.ControlPlane.Status.OIDCProvider.ARN
 	}
 
@@ -168,6 +173,7 @@ func (s *Service) deleteOIDCProvider() error {
 		return errors.Wrap(err, "failed to update control plane with OIDC provider ARN")
 	}
 
+	// Remove OidcProviderArnAnnotation after successfully deleting oidc provider
 	annotations[OidcProviderArnAnnotation] = ""
 	s.scope.ControlPlane.SetAnnotations(annotations)
 

--- a/pkg/cloud/services/eks/oidc.go
+++ b/pkg/cloud/services/eks/oidc.go
@@ -140,8 +140,8 @@ func (s *Service) reconcileTrustPolicy() error {
 }
 
 func (s *Service) deleteOIDCProvider() error {
-	anno := s.scope.ControlPlane.GetAnnotations()
-	arn := anno["aws.spectrocloud.com/oidcProviderArn"]
+	annotations := s.scope.ControlPlane.GetAnnotations()
+	arn := annotations["aws.spectrocloud.com/oidcProviderArn"]
 
 	if arn == "" {
 		arn = s.scope.ControlPlane.Status.OIDCProvider.ARN
@@ -161,8 +161,8 @@ func (s *Service) deleteOIDCProvider() error {
 		return errors.Wrap(err, "failed to update control plane with OIDC provider ARN")
 	}
 
-	anno["aws.spectrocloud.com/oidcProviderArn"] = ""
-	s.scope.ControlPlane.SetAnnotations(anno)
+	annotations["aws.spectrocloud.com/oidcProviderArn"] = ""
+	s.scope.ControlPlane.SetAnnotations(annotations)
 
 	return nil
 }

--- a/pkg/cloud/services/eks/oidc.go
+++ b/pkg/cloud/services/eks/oidc.go
@@ -161,6 +161,9 @@ func (s *Service) deleteOIDCProvider() error {
 		return errors.Wrap(err, "failed to update control plane with OIDC provider ARN")
 	}
 
+	anno["aws.spectrocloud.com/oidcProviderArn"] = ""
+	s.scope.ControlPlane.SetAnnotations(anno)
+
 	return nil
 }
 

--- a/pkg/cloud/services/eks/oidc.go
+++ b/pkg/cloud/services/eks/oidc.go
@@ -37,10 +37,10 @@ import (
 )
 
 const (
-	// OidcProviderArnAnnotation set/unset this annotation to managed control plane.
+	// OIDCProviderARNAnnotation set/unset this annotation to managed control plane.
 	// This is required in case of force pivot control plane status do not have ARN in status.
 	// In that cases annotation will be used to delete oidc resource.
-	OidcProviderArnAnnotation = "aws.spectrocloud.com/oidcProviderArn"
+	OIDCProviderARNAnnotation = "aws.spectrocloud.com/oidcProviderArn"
 )
 
 func (s *Service) reconcileOIDCProvider(cluster *eks.Cluster) error {
@@ -63,7 +63,7 @@ func (s *Service) reconcileOIDCProvider(cluster *eks.Cluster) error {
 		if anno == nil {
 			anno = make(map[string]string)
 		}
-		anno[OidcProviderArnAnnotation] = oidcProvider
+		anno[OIDCProviderARNAnnotation] = oidcProvider
 		s.scope.ControlPlane.SetAnnotations(anno)
 		if err := s.scope.PatchObject(); err != nil {
 			return errors.Wrap(err, "failed to update control plane with OIDC provider ARN")
@@ -149,13 +149,13 @@ func (s *Service) reconcileTrustPolicy() error {
 func (s *Service) deleteOIDCProvider() error {
 
 	// In case of force pivot managed control plane do not have ARN in status, that lead to oidcProvider not getting cleaned up during delete.
-	// OidcProviderArnAnnotation will be used to avoid it.
+	// OIDCProviderARNAnnotation will be used to avoid it.
 
 	annotations := s.scope.ControlPlane.GetAnnotations()
-	arn := annotations[OidcProviderArnAnnotation]
+	arn := annotations[OIDCProviderARNAnnotation]
 
 	if arn == "" {
-		// Upgrade support for cluster without OidcProviderArnAnnotation set
+		// Upgrade support for cluster without OIDCProviderARNAnnotation set
 		arn = s.scope.ControlPlane.Status.OIDCProvider.ARN
 	}
 
@@ -173,8 +173,8 @@ func (s *Service) deleteOIDCProvider() error {
 		return errors.Wrap(err, "failed to update control plane with OIDC provider ARN")
 	}
 
-	// Remove OidcProviderArnAnnotation after successfully deleting oidc provider
-	annotations[OidcProviderArnAnnotation] = ""
+	// Remove OIDCProviderARNAnnotation after successfully deleting oidc provider
+	annotations[OIDCProviderARNAnnotation] = ""
 	s.scope.ControlPlane.SetAnnotations(annotations)
 
 	return nil

--- a/pkg/cloud/services/eks/oidc.go
+++ b/pkg/cloud/services/eks/oidc.go
@@ -63,7 +63,7 @@ func (s *Service) reconcileOIDCProvider(cluster *eks.Cluster) error {
 		if anno == nil {
 			anno = make(map[string]string)
 		}
-		anno["aws.spectrocloud.com/oidcProviderArn"] = oidcProvider
+		anno[OidcProviderArnAnnotation] = oidcProvider
 		s.scope.ControlPlane.SetAnnotations(anno)
 		if err := s.scope.PatchObject(); err != nil {
 			return errors.Wrap(err, "failed to update control plane with OIDC provider ARN")


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

## **What is the purpose of the pull request**
<!-- Enter a description of the change and why this change is needed -->
**Issue**: 
EKS cluster deletion stuck with error failed to delete OIDC provider

**Cause**: 
Data point for deleting oidc provider in delete reconcile flow now also considers OidcProviderAnnotation in awsmanagedControlPlane to handle cases like force pivot.
After delete annotation need to reset to avoid delete try again.

## **Implementation**
<!-- Explain the implementation of this feature or bug fix -->

<!-- Feature Request/Issue statment-->

<!-- Fix -->
**Fix**: Remote ARN from OidcProviderAnnotation after first successful deletetion.

## **Committer checklist**
Verified on:
- [x] EKS


**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits
