### PR TITLE
PCP-4375:  🚀 SUS-564: Support AL 2023

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmanagedmachinepools.yaml
@@ -540,6 +540,11 @@ spec:
                 - AL2_x86_64
                 - AL2_x86_64_GPU
                 - AL2_ARM_64
+                - AL2023_x86_64_STANDARD
+                - AL2023_ARM_64_STANDARD
+                - AL2023_x86_64_NVIDIA
+                - AL2023_x86_64_NEURON
+                - CUSTOM
                 type: string
               amiVersion:
                 description: AMIVersion defines the desired AMI release version. If

--- a/docs/book/src/crd/index.md
+++ b/docs/book/src/crd/index.md
@@ -20239,6 +20239,18 @@ int64
 </tr><tr><td><p>&#34;AL2_x86_64_GPU&#34;</p></td>
 <td><p>Al2x86_64GPU is the x86-64 GPU AMI type.</p>
 </td>
+<tr><td><p>&#34;AL2023_ARM_64_STANDARD&#34;</p></td>
+<td><p>Al2023Arm64 is the AL2023 Arm AMI type.</p>
+</td>
+</tr><tr><td><p>&#34;AL2023_x86_64_STANDARD&#34;</p></td>
+<td><p>Al2023x86_64 is the AL2023 x86 AMI type.</p>
+</td>
+</tr><tr><td><p>&#34;AL2023_x86_64_NVIDIA&#34;</p></td>
+<td><p>Al2023x86_64GPU is the AL2023 x86-64 NVIDIA AMI type.</p>
+</td>
+</tr><tr><td><p>&#34;AL2023_x86_64_NEURON&#34;</p></td>
+<td><p>Al2023x86_64Neuron is the AL2023 x86-64 NEURON AMI type.</p>
+</td>
 </tr></tbody>
 </table>
 <h3 id="infrastructure.cluster.x-k8s.io/v1beta1.ManagedMachinePoolCapacityType">ManagedMachinePoolCapacityType

--- a/exp/api/v1beta1/awsmanagedmachinepool_types.go
+++ b/exp/api/v1beta1/awsmanagedmachinepool_types.go
@@ -37,6 +37,14 @@ const (
 	Al2x86_64GPU ManagedMachineAMIType = "AL2_x86_64_GPU"
 	// Al2Arm64 is the Arm AMI type.
 	Al2Arm64 ManagedMachineAMIType = "AL2_ARM_64"
+	// Al2023x86_64 is the AL2023 x86-64 AMI type.
+	Al2023x86_64 ManagedMachineAMIType = "AL2023_x86_64_STANDARD"
+	// Al2023Arm64 is the AL2023 Arm AMI type.
+	Al2023Arm64 ManagedMachineAMIType = "AL2023_ARM_64_STANDARD"
+	// AL2023_x86_64_NVIDIA is the AL2023 x86-64 NVIDIA AMI type.
+	Al2023x86_64Nvidia ManagedMachineAMIType = "AL2023_x86_64_NVIDIA"
+	// AL2023_x86_64_NEURON is the AL2023 x86-64 NEURON AMI type.
+	Al2023x86_64Neuron ManagedMachineAMIType = "AL2023_x86_64_NEURON"
 )
 
 // ManagedMachinePoolCapacityType specifies the capacity type to be used for the managed MachinePool.
@@ -99,7 +107,7 @@ type AWSManagedMachinePoolSpec struct {
 	AMIVersion *string `json:"amiVersion,omitempty"`
 
 	// AMIType defines the AMI type
-	// +kubebuilder:validation:Enum:=AL2_x86_64;AL2_x86_64_GPU;AL2_ARM_64
+	// +kubebuilder:validation:Enum:=AL2_x86_64;AL2_x86_64_GPU;AL2_ARM_64;AL2023_x86_64_STANDARD;AL2023_ARM_64_STANDARD;AL2023_x86_64_NVIDIA;AL2023_x86_64_NEURON;CUSTOM
 	// +kubebuilder:default:=AL2_x86_64
 	// +optional
 	AMIType *ManagedMachineAMIType `json:"amiType,omitempty"`


### PR DESCRIPTION
## 🚀 What This PR Does

**Adds support for AL2023 AMI types**.

https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4960

---

##  Context 

This update enables users to define AL2023 as the AMI type when provisioning **Managed Machine Pools (MMPs)** using the `v1beta1` API version, improving compatibility with modern EKS setups.
