### PR TITLE
PCP-4205: 🐛  fix: separate control plane logging and vpc config updates 

### DIFF
--- a/pkg/cloud/services/eks/cluster.go
+++ b/pkg/cloud/services/eks/cluster.go
@@ -300,7 +300,9 @@ func makeVpcConfig(subnets infrav1.Subnets, endpointAccess ekscontrolplanev1.End
 		SubnetIds:             subnetIds,
 	}
 
-	if len(cidrs) > 0 {
+	isPrivateOnlyEndPoint := !aws.BoolValue(vpcConfig.EndpointPublicAccess) && aws.BoolValue(vpcConfig.EndpointPrivateAccess)
+
+	if len(cidrs) > 0 || isPrivateOnlyEndPoint {
 		vpcConfig.PublicAccessCidrs = cidrs
 	}
 	sg, ok := securityGroups[infrav1.SecurityGroupEKSNodeAdditional]

--- a/pkg/cloud/services/eks/cluster_test.go
+++ b/pkg/cloud/services/eks/cluster_test.go
@@ -234,6 +234,94 @@ func TestMakeVPCConfig(t *testing.T) {
 				PublicAccessCidrs: []*string{aws.String("10.0.0.0/24")},
 			},
 		},
+		{
+			name: "private only endpoint access",
+			input: input{
+				subnets: []infrav1.SubnetSpec{
+					{
+						ID:               idOne,
+						CidrBlock:        "10.0.10.0/24",
+						AvailabilityZone: "us-west-2a",
+						IsPublic:         false,
+					},
+					{
+						ID:               idTwo,
+						CidrBlock:        "10.0.10.1/24",
+						AvailabilityZone: "us-west-2b",
+						IsPublic:         false,
+					},
+				},
+				endpointAccess: ekscontrolplanev1.EndpointAccess{
+					Private:     aws.Bool(true),
+					PublicCIDRs: []*string{},
+				},
+			},
+			expect: &eks.VpcConfigRequest{
+				SubnetIds:             []*string{&idOne, &idTwo},
+				PublicAccessCidrs:     []*string{},
+				EndpointPrivateAccess: aws.Bool(true),
+			},
+		},
+		{
+			name: "public and private endpoint access",
+			input: input{
+				subnets: []infrav1.SubnetSpec{
+					{
+						ID:               idOne,
+						CidrBlock:        "10.0.10.0/24",
+						AvailabilityZone: "us-west-2a",
+						IsPublic:         false,
+					},
+					{
+						ID:               idTwo,
+						CidrBlock:        "10.0.10.1/24",
+						AvailabilityZone: "us-west-2b",
+						IsPublic:         false,
+					},
+				},
+				endpointAccess: ekscontrolplanev1.EndpointAccess{
+					Private:     aws.Bool(true),
+					Public:      aws.Bool(true),
+					PublicCIDRs: []*string{},
+				},
+			},
+			expect: &eks.VpcConfigRequest{
+				SubnetIds:             []*string{&idOne, &idTwo},
+				PublicAccessCidrs:     nil,
+				EndpointPrivateAccess: aws.Bool(true),
+				EndpointPublicAccess:  aws.Bool(true),
+			},
+		},
+		{
+			name: "public only endpoint access",
+			input: input{
+				subnets: []infrav1.SubnetSpec{
+					{
+						ID:               idOne,
+						CidrBlock:        "10.0.10.0/24",
+						AvailabilityZone: "us-west-2a",
+						IsPublic:         false,
+					},
+					{
+						ID:               idTwo,
+						CidrBlock:        "10.0.10.1/24",
+						AvailabilityZone: "us-west-2b",
+						IsPublic:         false,
+					},
+				},
+				endpointAccess: ekscontrolplanev1.EndpointAccess{
+					Private:     aws.Bool(false),
+					Public:      aws.Bool(true),
+					PublicCIDRs: []*string{},
+				},
+			},
+			expect: &eks.VpcConfigRequest{
+				SubnetIds:             []*string{&idOne, &idTwo},
+				PublicAccessCidrs:     nil,
+				EndpointPrivateAccess: aws.Bool(false),
+				EndpointPublicAccess:  aws.Bool(true),
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
ref: 
https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/3553#issue-1282858144
https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4918#issue-2236005251
https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/5441
https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/5442

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->
---
**What type of PR is this?**
/kind bug

---
**What this PR does / why we need it**:
What this PR does / why we need it:

EKS does not allow for both a VPC config update and a logging update in the same API call. If both of these changes are applied to the spec at once, then the AWSManagedControlPlane will fail to reconcile.

Addresses the restriction in the EKS API by separating logging and vpc config updates into two separate steps.

---

Try updating EKS cluster's logging config and vpc config at a time. 
EKS doesn't allow multiple types of updates at once and this would fail
aws eks update-cluster-config --name --resources-vpc-config '{"endpointPrivateAccess":true}' --logging '{"clusterLogging":[{"types":["authenticator"],"enabled":true}]}'

An error occurred (InvalidParameterException) when calling the UpdateClusterConfig operation: Only one type of update can be allowed.

---
Observed when CAPA reconciles private endpoints when EKS deployed with endpoint access: private 
```
271] [capa-controller-manager-694c8f6879-wxg8q] 1 controller.go:326] "msg"="Reconciler error" "error"="failed to reconcile control plane for AWSManagedControlPlane cluster-67bdf4503897e994b608c9f3/dustin-eks-privatetest-cp: failed reconciling cluster config: failed to update EKS cluster: InvalidParameterException: Cluster is already at the desired configuration with endpointPrivateAccess: true , endpointPublicAccess: false, and Public Endpoint Restrictions: [52.35.163.177/32, 44.233.247.65/32, 18.144.153.171/32, 52.6.49.233/32, 54.80.29.137/32, 13.52.68.206/32, 54.158.209.13/32, 44.232.106.120/32]\n{\n RespMetadata: {\n StatusCode: 400,\n RequestID: \"10163f97-d89b-44c1-bee1-75a3c476b980\"\n },\n ClusterName: \"dustin-eks-privatetest\",\n Message_: \"Cluster is already at the desired configuration with endpointPrivateAccess: true , endpointPublicAccess: false, and Public Endpoint Restrictions: [52.35.163.177/32, 44.233.247.65/32, 18.144.153.171/32, 52.6.49.233/32, 54.80.29.137/32, 13.52.68.206/32, 54.158.209.13/32, 44.232.106.120/32]\"\n}" "AWSManagedControlPlane"={"name":"dustin-eks-privatetest-cp","namespace":"cluster-67bdf4503897e994b608c9f3"} "controller"="awsmanagedcontrolplane" "controllerGroup"="controlplane.cluster.x-k8s.io" "controllerKind"="AWSManagedControlPlane" "name"="dustin-eks-privatetest-cp" "namespace"="cluster-67bdf4503897e994b608c9f3" "reconcileID"="81216a1c-47f8-4059-b3b4-4f9664c3806f"
```
---
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [ ] squashed commits
- [ ] includes documentation
- [ ] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
