### PR TITLE
PCP-3797: Added nil pointer check before dereferencing Nodegroup version

### DIFF
--- a/pkg/cloud/services/eks/nodegroup.go
+++ b/pkg/cloud/services/eks/nodegroup.go
@@ -337,6 +337,11 @@ func (s *NodegroupService) reconcileNodegroupVersion(ng *eks.Nodegroup) error {
 	if s.scope.Version() != nil {
 		specVersion = parseEKSVersion(*s.scope.Version())
 	}
+
+	// PCP-3797: Check for nil pointers before dereferencing 
+	if ng.Version == nil {
+		return fmt.Errorf("nodegroup version is nil, nodegroup status: %v", *ng.Status)
+	}
 	ngVersion := version.MustParseGeneric(*ng.Version)
 	specAMI := s.scope.ManagedMachinePool.Spec.AMIVersion
 	ngAMI := *ng.ReleaseVersion


### PR DESCRIPTION
Added a check to ensure that the nodegroup version is not nil before dereferencing it. 

**What type of PR is this?**

/kind bug

**What this PR does / why we need it:**

This PR adds a nil pointer check for the nodegroup version in the reconcileNodegroupVersion function. This prevents potential runtime panics caused by dereferencing a nil pointer when the nodegroup version is not set during AWSManagedMachinePool reconciliation .

Example:  When the nodegroup status in in "CREATE_FAILED" state  due to unsupported AWS Launch template in Palette   then the nodegroup version is nil and we encounter panic calls.

**Which issue(s) this PR fixes:**
Fixes https://spectrocloud.atlassian.net/browse/PCP-3797

Upstream fix : https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/5019
