### PR TITLE
PCP-4315: 🐛  🍒  fix validation for aws tags with spaces

### DIFF
--- a/api/v1beta1/tags.go
+++ b/api/v1beta1/tags.go
@@ -86,7 +86,7 @@ func (t Tags) Validate() []*field.Error {
 	const maxUserTagsAllowed = 50
 	var errs field.ErrorList
 	var userTagCount = len(t)
-	re := regexp.MustCompile(`^[a-zA-Z0-9\\s\_\.\:\=\+\-\@\/]*$`)
+	re := regexp.MustCompile(`^[a-zA-Z0-9\s\_\.\:\=\+\-\@\/]*$`)
 
 	for k, v := range t {
 		if len(k) < 1 {

--- a/api/v1beta1/tags_test.go
+++ b/api/v1beta1/tags_test.go
@@ -180,6 +180,13 @@ func TestTags_Validate(t *testing.T) {
 			expected: nil,
 		},
 		{
+			name: "no errors - spaces allowed",
+			self: Tags{
+				"validKey": "valid Value",
+			},
+			expected: nil,
+		},
+		{
 			name: "key cannot be empty",
 			self: Tags{
 				"": "validValue",


### PR DESCRIPTION
/kind bug

https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/3701
https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3702


What steps did you take and what happened:

The regex check for valid AWS tags does not accept spaces although it says it should and is accepted by AWS

kubectl apply -f controlplane.cluster.x-k8s.io_v1beta1_awsmanagedcontrolplane-control-plane.yaml
The AWSManagedControlPlane "control-plane" is invalid: spec.additionalTags: Invalid value: "Value With Space": value cannot have characters other than alphabets, numbers, spaces and _ . : / = + - @ .
This was introduced here:
https://github.com/kubernetes-sigs/cluster-api-provider-aws/commit/935b8d6b7f5851f11153f71c19c727de38a60bc6

What did you expect to happen:

Valid values with Spaces should be allowed.

Anything else you would like to add:
[Miscellaneous information that will assist in solving the issue.]

Isolated Example https://go.dev/play/p/jD22vzaHuCX

`\\s` should be `\s`

Environment:

Cluster-api-provider-aws version: 1.5.0
Kubernetes version: (use kubectl version): 1.22
OS (e.g. from /etc/os-release): N/A