### PR TITLE
PCP-3797:  [Backport] Fix from #956 to spectro-release-4.6

### DIFF
--- a/pkg/cloud/services/eks/nodegroup.go
+++ b/pkg/cloud/services/eks/nodegroup.go
@@ -337,6 +337,11 @@ func (s *NodegroupService) reconcileNodegroupVersion(ng *eks.Nodegroup) error {
 	if s.scope.Version() != nil {
 		specVersion = parseEKSVersion(*s.scope.Version())
 	}
+
+	// PCP-3797: Check for nil pointers before dereferencing 
+	if ng.Version == nil {
+		return fmt.Errorf("nodegroup version is nil, nodegroup status: %v", *ng.Status)
+	}
 	ngVersion := version.MustParseGeneric(*ng.Version)
 	specAMI := s.scope.ManagedMachinePool.Spec.AMIVersion
 	ngAMI := *ng.ReleaseVersion


### PR DESCRIPTION
Backport https://github.com/spectrocloud/cluster-api-provider-aws/pull/956