### PR TITLE
PCP-4653: Node pool customization not working without specifying AMI ID

### DIFF
--- a/pkg/cloud/services/eks/nodegroup.go
+++ b/pkg/cloud/services/eks/nodegroup.go
@@ -222,7 +222,10 @@ func (s *NodegroupService) createNodegroup() (*eks.Nodegroup, error) {
 		RemoteAccess:  remoteAccess,
 		UpdateConfig:  s.updateConfig(),
 	}
-	if managedPool.AMIType != nil && (managedPool.AWSLaunchTemplate == nil || managedPool.AWSLaunchTemplate.AMI.ID == nil) {
+
+	// Palette have all input for nodepool customization as optionsl.
+	// Allow creating AWS launch templates without specifying an AMI ID. CAPA will do lookup for the AMI ID.
+	if managedPool.AMIType != nil && (managedPool.AWSLaunchTemplate == nil /*|| managedPool.AWSLaunchTemplate.AMI.ID == nil*/) {
 		input.AmiType = aws.String(string(*managedPool.AMIType))
 	}
 	if managedPool.DiskSize != nil {


### PR DESCRIPTION
Allow user to configure node pool customization without specifying amiID and with amiType other than CUSTOM.


Nodepool custmization without AMI ID.

![Screenshot 2025-06-05 at 3 29 27 PM](https://github.com/user-attachments/assets/7ff6315a-ff2c-4bc1-8021-48aa3c06ef9a)

Workerpool launched with default AmiType AL2_x86_64
![Screenshot 2025-06-05 at 3 28 16 PM](https://github.com/user-attachments/assets/ccc29525-7a4b-4c41-addd-1b6e3a6465a3)
![Screenshot 2025-06-05 at 4 04 02 PM](https://github.com/user-attachments/assets/915058b7-9ec5-45c1-9dcc-df46fd0ba426)
![Screenshot 2025-06-05 at 4 04 14 PM](https://github.com/user-attachments/assets/e1ff8116-4590-463a-a267-8af74cb330fd)


Create customization with label (spectrocloud.com/ami-type:AL2023_x86_64_STANDARD)

![Screenshot 2025-06-05 at 4 13 07 PM](https://github.com/user-attachments/assets/e9d71e9b-b8b1-4552-b269-c24edc0559b0)

