### PR TITLE
PCP-5517: fixed setting clustercidr and dns in NodeInput

### DIFF
--- a/bootstrap/eks/controllers/eksconfig_controller.go
+++ b/bootstrap/eks/controllers/eksconfig_controller.go
@@ -287,7 +287,7 @@ func (r *EKSConfigReconciler) joinWorker(ctx context.Context, cluster *clusterv1
 		DiskSetup:                config.Spec.DiskSetup,
 		Mounts:                   config.Spec.Mounts,
 		Files:                    files,
-		ClusterCIDR:              controlPlane.Spec.NetworkSpec.VPC.CidrBlock,
+		ClusterCIDR:              r.getClusterCidr(cluster, controlPlane),
 	}
 
 	if config.Spec.PauseContainer != nil {
@@ -586,4 +586,12 @@ func (r *EKSConfigReconciler) extractCAFromSecret(ctx context.Context, obj clien
 	}
 
 	return "", fmt.Errorf("no cluster with CA data found in kubeconfig")
+}
+
+func (r *EKSConfigReconciler) getClusterCidr(cluster *clusterv1.Cluster, controlPlane *ekscontrolplanev1.AWSManagedControlPlane) string {
+	if cluster.Spec.ClusterNetwork != nil && cluster.Spec.ClusterNetwork.Services != nil && len(cluster.Spec.ClusterNetwork.Services.CIDRBlocks) > 0 {
+		return cluster.Spec.ClusterNetwork.Services.CIDRBlocks[0]
+	}
+
+	return controlPlane.Spec.NetworkSpec.VPC.CidrBlock
 }

--- a/bootstrap/eks/internal/userdata/node.go
+++ b/bootstrap/eks/internal/userdata/node.go
@@ -402,7 +402,11 @@ func validateAL2023Input(input *NodeInput) error {
 		}
 	}
 	if input.DNSClusterIP == nil {
-		input.DNSClusterIP = ptr.To[string]("10.96.0.10")
+		if input.ClusterCIDR != "" {
+			input.DNSClusterIP = ptr.To(calculateDNSFromServiceCIDR(input.ClusterCIDR))
+		} else {
+			input.DNSClusterIP = ptr.To[string]("10.96.0.10")
+		}
 	}
 	input.ClusterDNS = *input.DNSClusterIP
 
@@ -414,4 +418,11 @@ func validateAL2023Input(input *NodeInput) error {
 		*input.MaxPods, *input.DNSClusterIP, input.AMIImageID, input.getCapacityTypeString())
 
 	return nil
+}
+
+// calculateDNSFromServiceCIDR calculates the DNS cluster IP by replacing the last octet with 10.
+func calculateDNSFromServiceCIDR(cidr string) string {
+	ipStr := strings.Split(strings.TrimSpace(cidr), "/")[0]
+	lastDotIdx := strings.LastIndex(ipStr, ".")
+	return ipStr[:lastDotIdx] + ".10"
 }


### PR DESCRIPTION
Testing:

Created two worker pools, with and without node customization. The node group with node customization has a proper CIDR aligned with the service CIDR of the cluster.

**Before fix:**
Service CIDR: 10.96.0.0/12
Node group w/o customization: 10.96.0.0/12
Node group with customization: 10.0.0.0/16


**After fix:**
Service CIDR: 10.96.0.0/12
Node group w/o customization: 10.96.0.0/12
Node group with customization: 10.96.0.0/12

