### PR TITLE
change to 1.24.12 for spectro-release

### DIFF
--- a/.github/workflows/spectro-release.yaml
+++ b/.github/workflows/spectro-release.yaml
@@ -62,6 +62,8 @@ jobs:
         name: Build Image
         env:
           REGISTRY: ${{ env.LEGACY_REGISTRY }}
+          GO_VERSION: 1.24.12
+          BUILDER_GOLANG_VERSION: 1.24.12
         run: |
           make docker-build-all
           make docker-push-all
@@ -70,6 +72,8 @@ jobs:
         env:
           FIPS_ENABLE: yes
           REGISTRY: ${{ env.FIPS_REGISTRY }}
+          GO_VERSION: 1.24.12
+          BUILDER_GOLANG_VERSION: 1.24.12
         run: |
           make docker-build-all
           make docker-push-all


### PR DESCRIPTION
bump go 1.24.12 version 