### PR TITLE
:sparkles: eks: skip `aws:`-prefixed tags in nodegroup reconciliation

### DIFF
--- a/pkg/cloud/services/eks/tags.go
+++ b/pkg/cloud/services/eks/tags.go
@@ -19,6 +19,8 @@ package eks
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
@@ -62,15 +64,15 @@ func (s *Service) getEKSTagParams(id string) *infrav1.BuildParams {
 	}
 }
 
-func getTagUpdates(currentTags map[string]string, tags map[string]string) (untagKeys []string, newTags map[string]string) {
+func getTagUpdates(currentTags map[string]string, desiredTags map[string]string) (untagKeys []string, newTags map[string]string) {
 	untagKeys = []string{}
 	newTags = make(map[string]string)
 	for key := range currentTags {
-		if _, ok := tags[key]; !ok {
+		if _, ok := desiredTags[key]; !ok && !strings.HasPrefix(key, tags.AwsInternalTagPrefix) {
 			untagKeys = append(untagKeys, key)
 		}
 	}
-	for key, value := range tags {
+	for key, value := range desiredTags {
 		if currentV, ok := currentTags[key]; !ok || value != currentV {
 			newTags[key] = value
 		}
@@ -78,7 +80,7 @@ func getTagUpdates(currentTags map[string]string, tags map[string]string) (untag
 	return untagKeys, newTags
 }
 
-func getASGTagUpdates(clusterName string, currentTags map[string]string, tags map[string]string) (tagsToDelete map[string]string, tagsToAdd map[string]string) {
+func getASGTagUpdates(clusterName string, currentTags, desiredTags map[string]string) (tagsToDelete, tagsToAdd map[string]string) {
 	officialASGTagsByEKS := []string{
 		eksClusterNameTag,
 		eksNodeGroupNameTag,
@@ -89,20 +91,11 @@ func getASGTagUpdates(clusterName string, currentTags map[string]string, tags ma
 	tagsToDelete = make(map[string]string)
 	tagsToAdd = make(map[string]string)
 	for k, v := range currentTags {
-		if _, ok := tags[k]; !ok {
-			isOfficialTag := false
-			for _, tag := range officialASGTagsByEKS {
-				if tag == k {
-					isOfficialTag = true
-					break
-				}
-			}
-			if !isOfficialTag {
-				tagsToDelete[k] = v
-			}
+		if _, ok := desiredTags[k]; !ok && !slices.Contains(officialASGTagsByEKS, k) {
+			tagsToDelete[k] = v
 		}
 	}
-	for key, value := range tags {
+	for key, value := range desiredTags {
 		if currentV, ok := currentTags[key]; !ok || value != currentV {
 			tagsToAdd[key] = value
 		}
@@ -136,16 +129,12 @@ func (s *NodegroupService) reconcileASGTags(ng *eks.Nodegroup) error {
 	if len(tagsToAdd) > 0 {
 		input := &autoscaling.CreateOrUpdateTagsInput{}
 		for k, v := range tagsToAdd {
-			// The k/vCopy is used to address the "Implicit memory aliasing in for loop" issue
-			// https://stackoverflow.com/questions/62446118/implicit-memory-aliasing-in-for-loop
-			kCopy := k
-			vCopy := v
 			input.Tags = append(input.Tags, &autoscaling.Tag{
-				Key:               &kCopy,
+				Key:               ptr.To(k),
 				PropagateAtLaunch: aws.Bool(true),
 				ResourceId:        asg.AutoScalingGroupName,
-				ResourceType:      ptr.To[string]("auto-scaling-group"),
-				Value:             &vCopy,
+				ResourceType:      ptr.To("auto-scaling-group"),
+				Value:             ptr.To(v),
 			})
 		}
 		_, err = s.AutoscalingClient.CreateOrUpdateTagsWithContext(context.TODO(), input)
@@ -157,13 +146,10 @@ func (s *NodegroupService) reconcileASGTags(ng *eks.Nodegroup) error {
 	if len(tagsToDelete) > 0 {
 		input := &autoscaling.DeleteTagsInput{}
 		for k := range tagsToDelete {
-			// The k/vCopy is used to address the "Implicit memory aliasing in for loop" issue
-			// https://stackoverflow.com/questions/62446118/implicit-memory-aliasing-in-for-loop
-			kCopy := k
 			input.Tags = append(input.Tags, &autoscaling.Tag{
-				Key:          &kCopy,
+				Key:          ptr.To(k),
 				ResourceId:   asg.AutoScalingGroupName,
-				ResourceType: ptr.To[string]("auto-scaling-group"),
+				ResourceType: ptr.To("auto-scaling-group"),
 			})
 		}
 		_, err = s.AutoscalingClient.DeleteTagsWithContext(context.TODO(), input)

--- a/pkg/cloud/services/eks/tags_test.go
+++ b/pkg/cloud/services/eks/tags_test.go
@@ -42,6 +42,18 @@ func TestGetTagUpdates(t *testing.T) {
 				"x": "2",
 			},
 		},
+		{
+			current: map[string]string{
+				"kubernetes.io/cluster/foo":     "owned",
+				"aws:cloudformation:stack-name": "eks-stack",
+				"nodegroup-name":                "ng1",
+			},
+			next: map[string]string{
+				"kubernetes.io/cluster/foo": "owned",
+			},
+			expectUntag: []string{"nodegroup-name"},
+			expectTag:   map[string]string{},
+		},
 	}
 	for i, tc := range testCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {


### PR DESCRIPTION
When reconciling tags for EKS managed nodegroups and Fargate profiles, ignore `aws:`-prefixed keys when building the list of keys to remove, using the same reserved-prefix logic as `pkg/cloud/tags` for tag application.

Those tags are not part of CAPA’s desired tag map since the validating webhooks forbid them in `additionalTags`, but they can exist on nodegroups created outside of CAPA (e.g., via CloudFormation). Including them in `UntagResource` triggers an API validation error, failing reconciliation and adoption of pre-existing nodegroups.

Additionally, this changelist also replaces manual copying of variables (`kCopy`/`vCopy`) with `ptr.To()` so the loop-variable aliasing workaround is not required.

This has been tested on an eksctl-provisioned cluster which creates nodegroups using CloudFormation. The AWS-reserved tags on the nodegroup (`aws:cloudformation:stack-name`, `aws:cloudformation:logical-id` and `aws:cloudformation:stack-id`) were correctly skipped and reconciliation passed.

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind feature
<!--
Add one of the following kinds:

/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [ ] squashed commits
- [ ] includes documentation
- [ ] includes emoji in title 
- [x] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
