### PR TITLE
 🐛  PCP-6865 Letting CAPA bypass updating nodegroup version API call for custom AMI

### DIFF
--- a/pkg/cloud/services/eks/nodegroup.go
+++ b/pkg/cloud/services/eks/nodegroup.go
@@ -404,8 +404,20 @@ func (s *NodegroupService) reconcileNodegroupVersion(ng *eks.Nodegroup) error {
 
 	launchTemplateChanged := launchTemplateIDChanged || launchTemplateVersionChanged
 
+	// For CUSTOM AMI nodegroups the k8s version is baked into the AMI; AWS rejects
+	// UpdateNodegroupVersion without launch template details for these nodegroups, and a
+	// version-only bump is meaningless because the actual kubelet version is determined by
+	// the AMI, not the EKS version field. CAPI propagates the cluster control-plane version
+	// (e.g. 1.34) to all MachinePools, so there is always a perceived version mismatch when
+	// a CUSTOM AMI carries an older kubelet — leading to a 100k+ failure event loop on scale.
+	// Version upgrades for CUSTOM AMI pools happen implicitly when the user updates the launch
+	// template with a compatible AMI; that change is handled by the launchTemplateChanged path
+	// which correctly passes the launch template to UpdateNodegroupVersion.
+	ngIsCustomAMI := aws.StringValue(ng.AmiType) == eks.AMITypesCustom
+	versionUpgradeNeeded := specVersion != nil && ngVersion.LessThan(specVersion) && !ngIsCustomAMI
+
 	eksClusterName := s.scope.KubernetesClusterName()
-	if (specVersion != nil && ngVersion.LessThan(specVersion)) || (specAMI != nil && *specAMI != ngAMI) || launchTemplateChanged {
+	if versionUpgradeNeeded || (specAMI != nil && *specAMI != ngAMI) || launchTemplateChanged {
 		input := &eks.UpdateNodegroupVersionInput{
 			ClusterName:   aws.String(eksClusterName),
 			NodegroupName: aws.String(s.scope.NodegroupName()),
@@ -420,7 +432,7 @@ func (s *NodegroupService) reconcileNodegroupVersion(ng *eks.Nodegroup) error {
 				Version: statusLaunchTemplateVersion,
 			}
 			updateMsg = fmt.Sprintf("to launch template %s version %s", aws.StringValue(statusLaunchTemplateID), aws.StringValue(statusLaunchTemplateVersion))
-		case specVersion != nil && ngVersion.LessThan(specVersion):
+		case versionUpgradeNeeded:
 			// NOTE: you can only upgrade increments of minor versions. If you want to upgrade 1.14 to 1.16 we
 			// need to go 1.14-> 1.15 and then 1.15 -> 1.16.
 			input.Version = aws.String(versionToEKS(ngVersion.WithMinor(ngVersion.Minor() + 1)))


### PR DESCRIPTION
**Problem:**
According to the [ticket](https://spectrocloud.atlassian.net/browse/PCP-6865), a custom AMI with k8s version lesser than the EKS cluster's k8s version would let the nodes join the cluster correctly but CAPA would fail with error:
```
Message_: "Launch template details can't be null for Custom ami type node group" 
```

**RCA:**
The issue occurs because its in regular CAPA flow that if CAPI machine pool's k8s version exceeds the nodegroup's actual k8s version, CAPA will trigger an API call to update the nodegroup version to the desired one. However that call won't work here since we want to keep the k8s version as given by user and the API call expects launch template to be filled up in this case. The existing code doesn't contain any launch template addition/modification in this scenario.

**Fix:**
Including all of the already present cases, one more case is added which checks that if the AMI type is custom. If yes, then it even if the other cases satisfy, it won't trigger the upgrade API call.

**Verification:**
The EKS cluster with 1.34 k8s version now has a working nodegroup with custom AMI 1.33 version. The CAPA pod & cluster is stable.